### PR TITLE
Change http to http-socket in uwsgi

### DIFF
--- a/docker/conf/uwsgi.ini
+++ b/docker/conf/uwsgi.ini
@@ -1,5 +1,5 @@
 [uwsgi]
-http = :8000
+http-socket = 0.0.0.0:8000
 ;enable-threads=0
 ;honour-range=1
 ;master=1


### PR DESCRIPTION
This pull request includes a small change to the `docker/conf/uwsgi.ini` file. The change modifies the `http` configuration to use `http-socket` instead.

* [`docker/conf/uwsgi.ini`](diffhunk://#diff-b1188e4b8780c5dc9439d646f152ab5f95a203a36b1eacf4110311f936e0ccb2L2-R2): Changed `http` to `http-socket` for better network binding.