### PR TITLE
240796: Kobo import is not assigning household to individuals

### DIFF
--- a/src/country_workspace/contrib/kobo/sync.py
+++ b/src/country_workspace/contrib/kobo/sync.py
@@ -36,6 +36,7 @@ def create_individuals(
         individuals.append(
             Individual(
                 batch=batch,
+                household=household,
                 name=individual.get(fullname, ""),
                 flex_fields={clean_field_name(key): value for key, value in individual.items()},
             ),


### PR DESCRIPTION
# Legal Boilerplate

Look, I get it.
Contributing to HOPE Workspace, I retain all rights, title and interest in and to my contributions, and by keeping
this boilerplate intact I confirm that HOPE Workspace can use, modify, copy, and redistribute my contributions,
under HOPE's choice of terms.
