### PR TITLE
AB#247634: shield admin llink/icon should be visible only if the user is_staff

### DIFF
--- a/src/country_workspace/workspaces/templatetags/workspace_urls.py
+++ b/src/country_workspace/workspaces/templatetags/workspace_urls.py
@@ -20,38 +20,45 @@ from django.db.models.options import Options
 from django.urls import NoReverseMatch, reverse
 from django.utils.safestring import mark_safe
 
+from country_workspace.state import state
+
 logger = logging.getLogger(__name__)
 register = template.Library()
 
 
+ADMIN_CHANGE_VIEW = "admin:{app}_{model}_change"
+ADMIN_CHANGELIST_VIEW = "admin:{app}_{model}_changelist"
+ADMIN_URL = """
+<a class="admin-change-link" target="_admin" href="{url}?{query}">'
+    <span class="icon icon-shield1"></span>'
+"</a>"
+"""
+
+
 @register.simple_tag()
-def admin_url(obj: Model, **extra: dict[str, Any]) -> str:
+def admin_url(obj: Model | ModelAdmin | str | None, **extra: dict[str, Any]) -> str:
     url = ""
     filters = ""
-    if obj:
+    if state.request.user.is_staff and obj:
         try:
             if isinstance(obj, Model):
                 if obj._meta.proxy_for_model:
                     opts = obj._meta.proxy_for_model._meta
                 else:
                     opts = obj._meta
-                url = reverse("admin:%s_%s_change" % (opts.app_label, opts.model_name), args=(obj.pk,))
+                url = reverse(ADMIN_CHANGE_VIEW.format(app=opts.app_label, model=opts.model_name), args=(obj.pk,))
             elif isinstance(obj, ModelAdmin):
                 opts = obj.opts.proxy_for_model._meta
-                url = reverse("admin:%s_%s_changelist" % (opts.app_label, opts.model_name))
+                url = reverse(ADMIN_CHANGELIST_VIEW.format(app=opts.app_label, model=opts.model_name))
             elif isinstance(obj, str):
                 model = apps.get_model(obj)
                 opts = model._meta
-                url = reverse("admin:%s_%s_changelist" % (opts.app_label, opts.model_name))
+                url = reverse(ADMIN_CHANGELIST_VIEW.format(app=opts.app_label, model=opts.model_name))
 
             if extra:
                 filters = urllib.parse.urlencode(extra)
 
-            return mark_safe(  # noqa: S308
-                f'<a class="admin-change-link" target="_admin" href="{url}?{filters}">'
-                '<span class="icon icon-shield1"></span>'
-                "</a>",
-            )
+            return mark_safe(ADMIN_URL.format(url=url, query=filters))  # noqa: S308
         except NoReverseMatch as e:
             logger.exception(e)
 

--- a/tests/workspace/templatetags/test_workspace_urls.py
+++ b/tests/workspace/templatetags/test_workspace_urls.py
@@ -1,0 +1,80 @@
+from unittest.mock import Mock
+
+import pytest
+from django.contrib.auth.models import User
+from django.db.models import Model
+from django.db.models.options import Options
+from django.urls import NoReverseMatch
+from pytest_mock import MockerFixture
+
+from country_workspace.state import State
+from country_workspace.workspaces.templatetags.workspace_urls import ADMIN_CHANGE_VIEW, ADMIN_URL
+from src.country_workspace.workspaces.templatetags.workspace_urls import admin_url
+
+TEST_URL = "test_url"
+
+
+@pytest.fixture
+def state(mocker: MockerFixture) -> State:
+    return mocker.patch("src.country_workspace.workspaces.templatetags.workspace_urls.state")
+
+
+@pytest.fixture
+def user(state: State) -> User:
+    user = Mock(spec=User)
+    state.request.user = user
+    return user
+
+
+@pytest.fixture
+def options() -> Options:
+    options = Mock(spec=Options)
+    options.app_label = "test_app"
+    options.model_name = "test_model"
+    options.proxy_for_model = None
+    return options
+
+
+@pytest.fixture
+def model(options: Options) -> Model:
+    model = Mock(spec=Model)
+    model._meta = options
+    return model
+
+
+@pytest.fixture
+def reverse_mock(mocker: MockerFixture) -> Mock:
+    reverse = mocker.patch("src.country_workspace.workspaces.templatetags.workspace_urls.reverse")
+    reverse.return_value = TEST_URL
+    return reverse
+
+
+def test_admin_url_none_obj(user: User) -> None:
+    assert admin_url(None) == ""
+
+
+def test_admin_url_no_reverse_match(user: User, model: Model, options: Options, reverse_mock: Mock) -> None:
+    user.is_staff = True
+    reverse_mock.side_effect = NoReverseMatch()
+    assert admin_url(model) == ""
+    reverse_mock.assert_called_once_with(
+        ADMIN_CHANGE_VIEW.format(app=options.app_label, model=options.model_name), args=(model.pk,)
+    )
+
+
+def test_admin_url_user_is_not_staff(user: User, model: Model) -> None:
+    user.is_staff = False
+    assert admin_url(model) == ""
+
+
+@pytest.mark.parametrize("has_proxy", [True, False])
+def test_admin_url_user_is_staff_model_passed(
+    has_proxy: bool, user: User, model: Model, options: Options, reverse_mock: Mock
+) -> None:
+    user.is_staff = True
+    model._meta = options
+    options.proxy_for_model = model if has_proxy else None
+    assert admin_url(model) == ADMIN_URL.format(url=TEST_URL, query="")
+    reverse_mock.assert_called_once_with(
+        ADMIN_CHANGE_VIEW.format(app=options.app_label, model=options.model_name), args=(model.pk,)
+    )


### PR DESCRIPTION
[AB#247634](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/247634)