### PR TITLE
Bugfix/sentry id not generating

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -76,6 +76,7 @@ ignore = [
   "SLF001", # Private member accessed:
   "TD003", #  Missing issue link for this TODO
   "TID252", # Prefer absolute imports over relative imports from parent modules
+  "TRY400", # Use logging.exception instead of logging.error in exception handlers
   "TRY401", # Redundant exception object included in `logging.exception` call
   "TRY003", # Avoid specifying long messages outside the exception class
   "UP031", # Use format specifiers instead of percent format

--- a/src/country_workspace/workspaces/admin/cleaners/validate.py
+++ b/src/country_workspace/workspaces/admin/cleaners/validate.py
@@ -21,7 +21,7 @@ def validate_queryset(queryset: QuerySet[Model], **kwargs: Any) -> dict[str, int
             else:
                 invalid += 1
     except Exception as e:  # pragma: no cover
-        logger.exception(e)
+        logger.error(e)
         raise
 
     return {"valid": valid, "invalid": invalid}
@@ -38,7 +38,7 @@ def validate_program(job: AsyncJob) -> dict[str, int]:
             else:
                 invalid += 1
     except Exception as e:  # pragma: no cover
-        logger.exception(e)
+        logger.error(e)
         raise
 
     return {"valid": valid, "invalid": invalid}


### PR DESCRIPTION
When an exception is captured by the logger's Sentry integration, subsequent sentry_sdk.capture_exception() calls on the same exception object don't generate new IDs, leaving sentry_id empty