### PR TITLE
Bugfix: Import Celery app to make it available for django_celery_boost to use

### DIFF
--- a/src/country_workspace/workspaces/__init__.py
+++ b/src/country_workspace/workspaces/__init__.py
@@ -1,0 +1,5 @@
+# this import is required for django_celery_results to have access to the
+# configured Celery application. without it, it's possible that
+# celery.current_app will be set to a newly created application with the default
+# configuration
+from country_workspace.config.celery import app  # noqa: F401


### PR DESCRIPTION
# Legal Boilerplate

Look, I get it.
Contributing to HOPE Workspace, I retain all rights, title and interest in and to my contributions, and by keeping
this boilerplate intact I confirm that HOPE Workspace can use, modify, copy, and redistribute my contributions,
under HOPE's choice of terms.
