### PR TITLE
HOTFIX: Avoid running update_cache for every deleted record when cleaning the…

### DIFF
--- a/src/country_workspace/cache/handlers.py
+++ b/src/country_workspace/cache/handlers.py
@@ -1,4 +1,6 @@
-from typing import Any
+import contextlib
+from threading import local
+from typing import Any, Iterator
 
 from django.db.models import Model
 from django.db.models.signals import post_delete, post_save
@@ -16,9 +18,29 @@ from ..workspaces.models import (
 )
 from .manager import cache_manager
 
+_suppression = local()
+
+
+@contextlib.contextmanager
+def suppress_cache_updates() -> Iterator[None]:
+    """Temporarily disable the per-row update_cache signal handler.
+
+    Use this around bulk operations (e.g. wiping a whole program) where
+    invalidating the program's cache version once at the end is equivalent
+    and avoids O(N) Redis + DB round-trips per deleted row.
+    """
+    prev = getattr(_suppression, "active", False)
+    _suppression.active = True
+    try:
+        yield
+    finally:
+        _suppression.active = prev
+
 
 @receiver([post_save, post_delete])
 def update_cache(sender: "type[Model]", instance: Model, **kwargs: Any) -> None:
+    if getattr(_suppression, "active", False):
+        return
     program = None
     office = None
     if isinstance(instance, (Household | Individual | CountryHousehold | CountryIndividual)):

--- a/src/country_workspace/tasks.py
+++ b/src/country_workspace/tasks.py
@@ -5,9 +5,10 @@ from typing import Any, Generator
 import sentry_sdk
 from celery.exceptions import Ignore
 from django.core.cache import cache
-from django.db import transaction
 from redis_lock import Lock
 
+from country_workspace.cache.handlers import suppress_cache_updates
+from country_workspace.cache.manager import cache_manager
 from country_workspace.config.celery import app
 from country_workspace.models import AsyncJob, Batch, Rdp, Rdi
 from country_workspace.models.jobs import GracefulJobCancellationError
@@ -64,9 +65,10 @@ def removed_expired_jobs(**kwargs: Any) -> None:
     AsyncJob.objects.filter(**kwargs).delete()
 
 
-def clean_program_data(job: AsyncJob, batch_size: int = 1000) -> dict | None:
+def clean_program_data(job: AsyncJob, batch_size: int = 5) -> dict | None:
     job.ensure_not_cancelled(refresh=True)
-    program_id = job.program.pk
+    program = job.program
+    program_id = program.pk
     current_job_id = job.pk
     deleted_counts = {"batches": 0, "households": 0, "individuals": 0, "rdps": 0, "rdis": 0, "jobs": 0}
 
@@ -74,25 +76,28 @@ def clean_program_data(job: AsyncJob, batch_size: int = 1000) -> dict | None:
     if not batch_ids:
         return None
 
-    for i in range(0, len(batch_ids), batch_size):
-        job.ensure_not_cancelled(refresh=True)
-        chunk = batch_ids[i : i + batch_size]
-        with transaction.atomic():
-            _, counts = Batch.objects.filter(id__in=chunk).delete()
-            deleted_counts["batches"] += counts.get("country_workspace.Batch", 0)
-            deleted_counts["households"] += counts.get("country_workspace.Household", 0)
-            deleted_counts["individuals"] += counts.get("country_workspace.Individual", 0)
+    try:
+        with suppress_cache_updates():
+            for i in range(0, len(batch_ids), batch_size):
+                job.ensure_not_cancelled(refresh=True)
+                chunk = batch_ids[i : i + batch_size]
+                _, counts = Batch.objects.filter(id__in=chunk).delete()
+                deleted_counts["batches"] += counts.get("country_workspace.Batch", 0)
+                deleted_counts["households"] += counts.get("country_workspace.Household", 0)
+                deleted_counts["individuals"] += counts.get("country_workspace.Individual", 0)
 
-    job.ensure_not_cancelled(refresh=True)
-    _, counts = Rdp.objects.filter(program_id=program_id).delete()
-    deleted_counts["rdps"] = counts.get("country_workspace.Rdp", 0)
+            job.ensure_not_cancelled(refresh=True)
+            _, counts = Rdp.objects.filter(program_id=program_id).delete()
+            deleted_counts["rdps"] = counts.get("country_workspace.Rdp", 0)
 
-    job.ensure_not_cancelled(refresh=True)
-    _, counts = Rdi.objects.filter(program_id=program_id).delete()
-    deleted_counts["rdis"] = counts.get("country_workspace.Rdi", 0)
+            job.ensure_not_cancelled(refresh=True)
+            _, counts = Rdi.objects.filter(program_id=program_id).delete()
+            deleted_counts["rdis"] = counts.get("country_workspace.Rdi", 0)
 
-    job.ensure_not_cancelled(refresh=True)
-    _, counts = AsyncJob.objects.filter(program_id=program_id).exclude(id=current_job_id).delete()
-    deleted_counts["jobs"] = counts.get("country_workspace.AsyncJob", 0)
+            job.ensure_not_cancelled(refresh=True)
+            _, counts = AsyncJob.objects.filter(program_id=program_id).exclude(id=current_job_id).delete()
+            deleted_counts["jobs"] = counts.get("country_workspace.AsyncJob", 0)
+    finally:
+        cache_manager.incr_cache_version(program=program)
 
     return deleted_counts

--- a/src/country_workspace/tasks.py
+++ b/src/country_workspace/tasks.py
@@ -73,8 +73,6 @@ def clean_program_data(job: AsyncJob, batch_size: int = 5) -> dict | None:
     deleted_counts = {"batches": 0, "households": 0, "individuals": 0, "rdps": 0, "rdis": 0, "jobs": 0}
 
     batch_ids = list(Batch.objects.filter(program_id=program_id).values_list("id", flat=True))
-    if not batch_ids:
-        return None
 
     try:
         with suppress_cache_updates():

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -3,6 +3,7 @@ from unittest.mock import patch, PropertyMock
 
 from celery.exceptions import Ignore
 
+from country_workspace.cache.manager import cache_manager
 from country_workspace.config.celery import app, init_sentry
 from country_workspace.models import Household, Individual, Batch, Rdp, Rdi, AsyncJob
 from country_workspace.models.jobs import GracefulJobCancellationError
@@ -205,6 +206,25 @@ def test_clean_program_data_stops_when_cancellation_requested(job, batch, househ
             clean_program_data(job, batch_size=1)
 
     assert Batch.objects.filter(program=job.program).count() == initial_batches
+
+
+@pytest.mark.django_db
+def test_clean_program_data_bumps_cache_version_exactly_once(job, batch, households, individuals):
+    program = job.program
+    version_before = cache_manager.get_cache_version(program=program)
+
+    result = clean_program_data(job, batch_size=5)
+
+    assert result is not None
+    assert result["households"] > 0
+    assert result["individuals"] > 0
+
+    version_after = cache_manager.get_cache_version(program=program)
+    assert version_after == version_before + 1, (
+        "cache version must be bumped exactly once: per-row post_save/post_delete "
+        "updates are suppressed during the bulk delete and a single bump is issued "
+        "at the end"
+    )
 
 
 @pytest.mark.django_db

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -163,13 +163,6 @@ def test_clean_program_data_multiple_batches(job):
 
 
 @pytest.mark.django_db
-def test_clean_program_data_empty_program(job):
-    result = clean_program_data(job)
-
-    assert result is None
-
-
-@pytest.mark.django_db
 def test_clean_program_data_does_not_affect_other_programs(job, batch, households):
     other_program = ProgramFactory.create()
     other_batch = BatchFactory.create(program=other_program)


### PR DESCRIPTION
[AB#310886](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/310886)

Update cache version only after the program is cleaned instead of calling it for every record
