### PR TITLE
Improve document report

### DIFF
--- a/src/country_workspace/contrib/hope/constants.py
+++ b/src/country_workspace/contrib/hope/constants.py
@@ -17,4 +17,5 @@ ACCOUNT_FIELDSET_NAME: Final[str] = "HOPE Account"
 DOCUMENT_FIELDSET_NAME: Final[str] = "HOPE Document"
 
 DOCUMENT_TYPES = ("national_id", "national_passport")
+MAX_DOCUMENT_COLUMNS = 3
 ACCOUNT_TYPES = ("mobile", "bank")

--- a/src/country_workspace/utils/document_columns.py
+++ b/src/country_workspace/utils/document_columns.py
@@ -7,10 +7,7 @@ from country_workspace.contrib.hope.constants import DOCUMENT_TYPES, MAX_DOCUMEN
 
 _COLUMN_RE = re.compile(r"^document_(\d+)_(type|number|country|expire_date)$")
 
-_NORMALIZED_TYPES: dict[str, str] = {}
-for _t in DOCUMENT_TYPES:
-    _NORMALIZED_TYPES[_t] = _t
-    _NORMALIZED_TYPES[_t.replace("_", " ")] = _t
+_NORMALIZED_TYPES: dict[str, str] = {key: t for t in DOCUMENT_TYPES for key in (t, t.replace("_", " "))}
 
 _FIELD_SUFFIX_MAP = {
     "number": "document_number",

--- a/src/country_workspace/utils/document_columns.py
+++ b/src/country_workspace/utils/document_columns.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from country_workspace.contrib.hope.constants import DOCUMENT_TYPES, MAX_DOCUMENT_COLUMNS
+
+_COLUMN_RE = re.compile(r"^document_(\d+)_(type|number|country|expire_date)$")
+
+_NORMALIZED_TYPES: dict[str, str] = {}
+for _t in DOCUMENT_TYPES:
+    _NORMALIZED_TYPES[_t] = _t
+    _NORMALIZED_TYPES[_t.replace("_", " ")] = _t
+
+_FIELD_SUFFIX_MAP = {
+    "number": "document_number",
+    "country": "country",
+    "expire_date": "expiry_date",
+}
+
+
+class DocumentColumnError(ValueError):
+    pass
+
+
+def _resolve_document_type(raw_value: Any) -> str:
+    if not raw_value or not isinstance(raw_value, str) or not raw_value.strip():
+        raise DocumentColumnError(f"Invalid document type: {raw_value}")
+    key = raw_value.strip().lower().replace("-", "_").replace("_", " ").strip()
+    key = re.sub(r"\s+", " ", key)
+    if key in _NORMALIZED_TYPES:
+        return _NORMALIZED_TYPES[key]
+    normalized_underscore = key.replace(" ", "_")
+    if normalized_underscore in _NORMALIZED_TYPES:
+        return _NORMALIZED_TYPES[normalized_underscore]
+    raise DocumentColumnError(f"Unknown document type: {raw_value!r}. Valid types: {', '.join(DOCUMENT_TYPES)}")
+
+
+def _present(value: Any) -> bool:
+    if value is None:
+        return False
+    return not isinstance(value, str) and not value.strip()
+
+
+def expand_document_columns(row: dict[str, Any]) -> dict[str, Any]:
+    """Convert numbered document columns to type-prefixed flex-field columns.
+
+    Recognizes ``document_X_type``, ``document_X_number``,
+    ``document_X_country`` and the optional ``document_X_expire_date``
+    where *X* is 1..MAX_DOCUMENT_COLUMNS.  Each populated triplet is
+    expanded into ``{type}_document_number``, ``{type}_country`` and
+    (optionally) ``{type}_expiry_date``.
+
+    If no ``document_X_*`` keys are found the row is returned unchanged.
+    """
+    slots: dict[int, dict[str, Any]] = {}
+    doc_keys: set[str] = set()
+
+    for key in list(row.keys()):
+        match = _COLUMN_RE.match(key)
+        if not match:
+            continue
+        idx, field = int(match.group(1)), match.group(2)
+        slots.setdefault(idx, {})[field] = row[key]
+        doc_keys.add(key)
+
+    if not slots:
+        return row
+
+    max_idx = max(slots)
+    if max_idx > MAX_DOCUMENT_COLUMNS:
+        raise DocumentColumnError(
+            f"Document index {max_idx} exceeds maximum of {MAX_DOCUMENT_COLUMNS}. "
+            f"Only document_1 through document_{MAX_DOCUMENT_COLUMNS} are allowed."
+        )
+
+    result = {k: v for k, v in row.items() if k not in doc_keys}
+
+    for idx in sorted(slots):
+        slot = slots[idx]
+        type_value = slot.get("type")
+
+        if not _present(type_value):
+            continue
+
+        internal_type = _resolve_document_type(type_value)
+        prefix = f"{internal_type}_"
+
+        number_value = slot.get("number")
+        country_value = slot.get("country")
+
+        if not _present(number_value) or not _present(country_value):
+            raise DocumentColumnError(
+                f"document_{idx}_number and document_{idx}_country are required when document_{idx}_type is provided"
+            )
+
+        for col_suffix, internal_suffix in _FIELD_SUFFIX_MAP.items():
+            value = slot.get(col_suffix)
+            if _present(value):
+                result[f"{prefix}{internal_suffix}"] = value
+
+    return result

--- a/src/country_workspace/utils/document_columns.py
+++ b/src/country_workspace/utils/document_columns.py
@@ -36,7 +36,7 @@ def _resolve_document_type(raw_value: Any) -> str:
 def _present(value: Any) -> bool:
     if value is None:
         return False
-    return not isinstance(value, str) and not value.strip()
+    return not (isinstance(value, str) and not value.strip())
 
 
 def expand_document_columns(row: dict[str, Any]) -> dict[str, Any]:

--- a/src/country_workspace/utils/document_columns.py
+++ b/src/country_workspace/utils/document_columns.py
@@ -3,9 +3,13 @@ from __future__ import annotations
 import re
 from typing import Any
 
-from country_workspace.contrib.hope.constants import DOCUMENT_TYPES, MAX_DOCUMENT_COLUMNS
+from country_workspace.contrib.hope.constants import (
+    DOCUMENT_TYPES,
+    MAX_DOCUMENT_COLUMNS,
+)
 
 _COLUMN_RE = re.compile(r"^document_(\d+)_(type|number|country|expire_date)$")
+_ANY_DOC_COLUMN_RE = re.compile(r"^document_(\d+)_(.+)$")
 
 _NORMALIZED_TYPES: dict[str, str] = {key: t for t in DOCUMENT_TYPES for key in (t, t.replace("_", " "))}
 
@@ -39,6 +43,62 @@ def _present(value: Any) -> bool:
     return not (isinstance(value, str) and not value.strip())
 
 
+def _collect_document_slots(row: dict[str, Any]) -> tuple[dict[int, dict[str, Any]], set[str]]:
+    slots: dict[int, dict[str, Any]] = {}
+    doc_keys: set[str] = set()
+    unknown_doc_keys: list[str] = []
+
+    for key, value in row.items():
+        if not isinstance(key, str):
+            continue
+        if (known_match := _COLUMN_RE.match(key)) is not None:
+            idx, field = int(known_match.group(1)), known_match.group(2)
+            slots.setdefault(idx, {})[field] = value
+            doc_keys.add(key)
+            continue
+        if _ANY_DOC_COLUMN_RE.match(key):
+            unknown_doc_keys.append(key)
+
+    if unknown_doc_keys:
+        raise DocumentColumnError(
+            "Unknown document column(s): "
+            f"{', '.join(sorted(unknown_doc_keys))}. "
+            "Allowed suffixes are: type, number, country, expire_date."
+        )
+
+    return slots, doc_keys
+
+
+def _validate_document_slot(idx: int, slot: dict[str, Any]) -> str | None:
+    type_value = slot.get("type")
+    has_other_values = any(_present(slot.get(field)) for field in ("number", "country", "expire_date"))
+
+    if not _present(type_value):
+        if has_other_values:
+            raise DocumentColumnError(
+                f"document_{idx}_type is required when other document_{idx}_* values are provided"
+            )
+        return None
+
+    number_value = slot.get("number")
+    country_value = slot.get("country")
+
+    if not _present(number_value):
+        raise DocumentColumnError(f"document_{idx}_number is required when document_{idx}_type is provided")
+    if not _present(country_value):
+        raise DocumentColumnError(f"document_{idx}_country is required when document_{idx}_type is provided")
+
+    return _resolve_document_type(type_value)
+
+
+def _apply_document_slot(result: dict[str, Any], slot: dict[str, Any], internal_type: str) -> None:
+    prefix = f"{internal_type}_"
+    for col_suffix, internal_suffix in _FIELD_SUFFIX_MAP.items():
+        value = slot.get(col_suffix)
+        if _present(value):
+            result[f"{prefix}{internal_suffix}"] = value
+
+
 def expand_document_columns(row: dict[str, Any]) -> dict[str, Any]:
     """Convert numbered document columns to type-prefixed flex-field columns.
 
@@ -50,16 +110,7 @@ def expand_document_columns(row: dict[str, Any]) -> dict[str, Any]:
 
     If no ``document_X_*`` keys are found the row is returned unchanged.
     """
-    slots: dict[int, dict[str, Any]] = {}
-    doc_keys: set[str] = set()
-
-    for key in list(row.keys()):
-        match = _COLUMN_RE.match(key)
-        if not match:
-            continue
-        idx, field = int(match.group(1)), match.group(2)
-        slots.setdefault(idx, {})[field] = row[key]
-        doc_keys.add(key)
+    slots, doc_keys = _collect_document_slots(row)
 
     if not slots:
         return row
@@ -74,26 +125,9 @@ def expand_document_columns(row: dict[str, Any]) -> dict[str, Any]:
     result = {k: v for k, v in row.items() if k not in doc_keys}
 
     for idx in sorted(slots):
-        slot = slots[idx]
-        type_value = slot.get("type")
-
-        if not _present(type_value):
+        internal_type = _validate_document_slot(idx, slots[idx])
+        if internal_type is None:
             continue
-
-        internal_type = _resolve_document_type(type_value)
-        prefix = f"{internal_type}_"
-
-        number_value = slot.get("number")
-        country_value = slot.get("country")
-
-        if not _present(number_value) or not _present(country_value):
-            raise DocumentColumnError(
-                f"document_{idx}_number and document_{idx}_country are required when document_{idx}_type is provided"
-            )
-
-        for col_suffix, internal_suffix in _FIELD_SUFFIX_MAP.items():
-            value = slot.get(col_suffix)
-            if _present(value):
-                result[f"{prefix}{internal_suffix}"] = value
+        _apply_document_slot(result, slots[idx], internal_type)
 
     return result

--- a/src/country_workspace/utils/import_processing.py
+++ b/src/country_workspace/utils/import_processing.py
@@ -7,6 +7,7 @@ from typing import Any
 from constance import config as constance_config
 
 from country_workspace.models import Batch, Household, Individual, Program
+from country_workspace.utils.document_columns import expand_document_columns
 from country_workspace.utils.fields import TO_UPPERCASE_FIELDS, clean_field_names
 
 Processor = Callable[[dict[str, Any]], dict[str, Any]]
@@ -77,6 +78,8 @@ def process_import_record(  # noqa: PLR0913
     data = dict(clean_field_names(data, fields_to_uppercase=fields_to_uppercase or TO_UPPERCASE_FIELDS))
     if apply_mapping:
         data = program.apply_mapping_importer(model, data, mapping_id=mapping_id, transformer_id=transformer_id)
+
+    data = expand_document_columns(data)
 
     for processor in post_processors or ():
         data = processor(data)

--- a/tests/utils/test_utils_document_columns.py
+++ b/tests/utils/test_utils_document_columns.py
@@ -47,6 +47,23 @@ def test_no_document_columns_returns_unchanged() -> None:
     assert result == row
 
 
+def test_non_string_column_keys_are_ignored() -> None:
+    row = {
+        1: "unexpected-header-index",
+        "given_name": "Ahmad",
+        "document_1_type": "national_id",
+        "document_1_number": "123456",
+        "document_1_country": "AF",
+    }
+    result = expand_document_columns(row)
+    assert result == {
+        1: "unexpected-header-index",
+        "given_name": "Ahmad",
+        "national_id_document_number": "123456",
+        "national_id_country": "AF",
+    }
+
+
 def test_single_document() -> None:
     row = {
         "given_name": "Ahmad",
@@ -158,6 +175,25 @@ def test_none_type_skips_slot() -> None:
         "national_id_document_number": "123",
         "national_id_country": "AF",
     }
+
+
+def test_missing_type_with_other_values_raises() -> None:
+    row = {
+        "document_1_number": "123",
+        "document_1_country": "AF",
+    }
+    with pytest.raises(DocumentColumnError, match="document_1_type is required"):
+        expand_document_columns(row)
+
+
+def test_unknown_document_suffix_raises() -> None:
+    row = {
+        "document_1_tpe": "national_id",
+        "document_1_number": "123",
+        "document_1_country": "AF",
+    }
+    with pytest.raises(DocumentColumnError, match="Unknown document column"):
+        expand_document_columns(row)
 
 
 def test_missing_number_raises() -> None:

--- a/tests/utils/test_utils_document_columns.py
+++ b/tests/utils/test_utils_document_columns.py
@@ -1,0 +1,273 @@
+import pytest
+
+from country_workspace.utils.document_columns import (
+    DocumentColumnError,
+    expand_document_columns,
+    _resolve_document_type,
+)
+
+
+class TestResolveDocumentType:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            pytest.param("national_id", "national_id", id="internal_name"),
+            pytest.param("national_passport", "national_passport", id="internal_passport"),
+            pytest.param("National ID", "national_id", id="display_name_title"),
+            pytest.param("NATIONAL_ID", "national_id", id="uppercase_underscore"),
+            pytest.param("national id", "national_id", id="lowercase_space"),
+            pytest.param("  national_id  ", "national_id", id="whitespace"),
+            pytest.param("national-id", "national_id", id="hyphenated"),
+            pytest.param("National Passport", "national_passport", id="passport_display"),
+            pytest.param("NATIONAL_PASSPORT", "national_passport", id="passport_upper"),
+        ],
+    )
+    def test_valid_types(self, raw: str, expected: str) -> None:
+        assert _resolve_document_type(raw) == expected
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            pytest.param("", id="empty"),
+            pytest.param("  ", id="whitespace_only"),
+            pytest.param(None, id="none"),
+            pytest.param(123, id="integer"),
+            pytest.param("unknown_type", id="unknown"),
+            pytest.param("birth_certificate", id="not_in_types"),
+        ],
+    )
+    def test_invalid_types(self, raw) -> None:
+        with pytest.raises(DocumentColumnError):
+            _resolve_document_type(raw)
+
+
+class TestExpandDocumentColumns:
+    def test_no_document_columns_returns_unchanged(self) -> None:
+        row = {"given_name": "Ahmad", "family_name": "Khan", "birth_date": "1990-01-01"}
+        result = expand_document_columns(row)
+        assert result == row
+
+    def test_single_document(self) -> None:
+        row = {
+            "given_name": "Ahmad",
+            "document_1_type": "national_id",
+            "document_1_number": "123456",
+            "document_1_country": "AF",
+        }
+        result = expand_document_columns(row)
+        assert result == {
+            "given_name": "Ahmad",
+            "national_id_document_number": "123456",
+            "national_id_country": "AF",
+        }
+
+    def test_single_document_with_expire_date(self) -> None:
+        row = {
+            "document_1_type": "national_passport",
+            "document_1_number": "P99887",
+            "document_1_country": "AF",
+            "document_1_expire_date": "2030-06-15",
+        }
+        result = expand_document_columns(row)
+        assert result == {
+            "national_passport_document_number": "P99887",
+            "national_passport_country": "AF",
+            "national_passport_expiry_date": "2030-06-15",
+        }
+
+    def test_multiple_documents(self) -> None:
+        row = {
+            "given_name": "Fatima",
+            "document_1_type": "national_id",
+            "document_1_number": "123456",
+            "document_1_country": "AF",
+            "document_2_type": "national_passport",
+            "document_2_number": "98765",
+            "document_2_country": "AF",
+            "document_2_expire_date": "2030-01-01",
+        }
+        result = expand_document_columns(row)
+        assert result == {
+            "given_name": "Fatima",
+            "national_id_document_number": "123456",
+            "national_id_country": "AF",
+            "national_passport_document_number": "98765",
+            "national_passport_country": "AF",
+            "national_passport_expiry_date": "2030-01-01",
+        }
+
+    def test_three_documents_max(self) -> None:
+        row = {
+            "document_1_type": "national_id",
+            "document_1_number": "111",
+            "document_1_country": "AF",
+            "document_2_type": "national_passport",
+            "document_2_number": "222",
+            "document_2_country": "AF",
+            "document_3_type": "national_id",
+            "document_3_number": "333",
+            "document_3_country": "PK",
+        }
+        result = expand_document_columns(row)
+        assert "national_id_document_number" in result
+        assert "national_passport_document_number" in result
+
+    def test_index_exceeds_max_raises(self) -> None:
+        row = {
+            "document_4_type": "national_id",
+            "document_4_number": "123",
+            "document_4_country": "AF",
+        }
+        with pytest.raises(DocumentColumnError, match="exceeds maximum"):
+            expand_document_columns(row)
+
+    def test_empty_type_skips_slot(self) -> None:
+        row = {
+            "given_name": "Omar",
+            "document_1_type": "national_id",
+            "document_1_number": "123",
+            "document_1_country": "AF",
+            "document_2_type": "",
+            "document_2_number": "",
+            "document_2_country": "",
+        }
+        result = expand_document_columns(row)
+        assert result == {
+            "given_name": "Omar",
+            "national_id_document_number": "123",
+            "national_id_country": "AF",
+        }
+
+    def test_none_type_skips_slot(self) -> None:
+        row = {
+            "document_1_type": "national_id",
+            "document_1_number": "123",
+            "document_1_country": "AF",
+            "document_2_type": None,
+            "document_2_number": None,
+            "document_2_country": None,
+        }
+        result = expand_document_columns(row)
+        assert result == {
+            "national_id_document_number": "123",
+            "national_id_country": "AF",
+        }
+
+    def test_missing_number_raises(self) -> None:
+        row = {
+            "document_1_type": "national_id",
+            "document_1_country": "AF",
+        }
+        with pytest.raises(DocumentColumnError, match="document_1_number is required"):
+            expand_document_columns(row)
+
+    def test_missing_country_raises(self) -> None:
+        row = {
+            "document_1_type": "national_id",
+            "document_1_number": "123",
+        }
+        with pytest.raises(DocumentColumnError, match="document_1_country is required"):
+            expand_document_columns(row)
+
+    def test_empty_number_raises(self) -> None:
+        row = {
+            "document_1_type": "national_id",
+            "document_1_number": "",
+            "document_1_country": "AF",
+        }
+        with pytest.raises(DocumentColumnError, match="document_1_number is required"):
+            expand_document_columns(row)
+
+    def test_empty_country_raises(self) -> None:
+        row = {
+            "document_1_type": "national_id",
+            "document_1_number": "123",
+            "document_1_country": "  ",
+        }
+        with pytest.raises(DocumentColumnError, match="document_1_country is required"):
+            expand_document_columns(row)
+
+    def test_optional_expire_date_missing(self) -> None:
+        row = {
+            "document_1_type": "national_id",
+            "document_1_number": "123",
+            "document_1_country": "AF",
+        }
+        result = expand_document_columns(row)
+        assert "national_id_expiry_date" not in result
+
+    def test_optional_expire_date_empty(self) -> None:
+        row = {
+            "document_1_type": "national_id",
+            "document_1_number": "123",
+            "document_1_country": "AF",
+            "document_1_expire_date": "",
+        }
+        result = expand_document_columns(row)
+        assert "national_id_expiry_date" not in result
+
+    def test_optional_expire_date_none(self) -> None:
+        row = {
+            "document_1_type": "national_id",
+            "document_1_number": "123",
+            "document_1_country": "AF",
+            "document_1_expire_date": None,
+        }
+        result = expand_document_columns(row)
+        assert "national_id_expiry_date" not in result
+
+    def test_preserves_non_document_fields(self) -> None:
+        row = {
+            "given_name": "Test",
+            "family_name": "User",
+            "birth_date": "2000-01-01",
+            "gender": "MALE",
+            "document_1_type": "national_id",
+            "document_1_number": "123",
+            "document_1_country": "AF",
+        }
+        result = expand_document_columns(row)
+        assert result["given_name"] == "Test"
+        assert result["family_name"] == "User"
+        assert result["birth_date"] == "2000-01-01"
+        assert result["gender"] == "MALE"
+
+    def test_numbered_columns_are_removed(self) -> None:
+        row = {
+            "document_1_type": "national_id",
+            "document_1_number": "123",
+            "document_1_country": "AF",
+            "document_1_expire_date": "2030-01-01",
+        }
+        result = expand_document_columns(row)
+        assert "document_1_type" not in result
+        assert "document_1_number" not in result
+        assert "document_1_country" not in result
+        assert "document_1_expire_date" not in result
+
+    def test_old_prefixed_format_passes_through(self) -> None:
+        row = {
+            "national_id_document_number": "123456",
+            "national_id_country": "AF",
+            "national_passport_document_number": "P99887",
+            "national_passport_country": "AF",
+        }
+        result = expand_document_columns(row)
+        assert result == row
+
+    def test_display_name_type_values(self) -> None:
+        row = {
+            "document_1_type": "National ID",
+            "document_1_number": "123",
+            "document_1_country": "AF",
+            "document_2_type": "National Passport",
+            "document_2_number": "456",
+            "document_2_country": "AF",
+        }
+        result = expand_document_columns(row)
+        assert result == {
+            "national_id_document_number": "123",
+            "national_id_country": "AF",
+            "national_passport_document_number": "456",
+            "national_passport_country": "AF",
+        }

--- a/tests/utils/test_utils_document_columns.py
+++ b/tests/utils/test_utils_document_columns.py
@@ -7,267 +7,284 @@ from country_workspace.utils.document_columns import (
 )
 
 
-class TestResolveDocumentType:
-    @pytest.mark.parametrize(
-        ("raw", "expected"),
-        [
-            pytest.param("national_id", "national_id", id="internal_name"),
-            pytest.param("national_passport", "national_passport", id="internal_passport"),
-            pytest.param("National ID", "national_id", id="display_name_title"),
-            pytest.param("NATIONAL_ID", "national_id", id="uppercase_underscore"),
-            pytest.param("national id", "national_id", id="lowercase_space"),
-            pytest.param("  national_id  ", "national_id", id="whitespace"),
-            pytest.param("national-id", "national_id", id="hyphenated"),
-            pytest.param("National Passport", "national_passport", id="passport_display"),
-            pytest.param("NATIONAL_PASSPORT", "national_passport", id="passport_upper"),
-        ],
-    )
-    def test_valid_types(self, raw: str, expected: str) -> None:
-        assert _resolve_document_type(raw) == expected
-
-    @pytest.mark.parametrize(
-        "raw",
-        [
-            pytest.param("", id="empty"),
-            pytest.param("  ", id="whitespace_only"),
-            pytest.param(None, id="none"),
-            pytest.param(123, id="integer"),
-            pytest.param("unknown_type", id="unknown"),
-            pytest.param("birth_certificate", id="not_in_types"),
-        ],
-    )
-    def test_invalid_types(self, raw) -> None:
-        with pytest.raises(DocumentColumnError):
-            _resolve_document_type(raw)
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        pytest.param("national_id", "national_id", id="internal_name"),
+        pytest.param("national_passport", "national_passport", id="internal_passport"),
+        pytest.param("National ID", "national_id", id="display_name_title"),
+        pytest.param("NATIONAL_ID", "national_id", id="uppercase_underscore"),
+        pytest.param("national id", "national_id", id="lowercase_space"),
+        pytest.param("  national_id  ", "national_id", id="whitespace"),
+        pytest.param("national-id", "national_id", id="hyphenated"),
+        pytest.param("National Passport", "national_passport", id="passport_display"),
+        pytest.param("NATIONAL_PASSPORT", "national_passport", id="passport_upper"),
+    ],
+)
+def test_resolve_document_type_valid(raw: str, expected: str) -> None:
+    assert _resolve_document_type(raw) == expected
 
 
-class TestExpandDocumentColumns:
-    def test_no_document_columns_returns_unchanged(self) -> None:
-        row = {"given_name": "Ahmad", "family_name": "Khan", "birth_date": "1990-01-01"}
-        result = expand_document_columns(row)
-        assert result == row
+@pytest.mark.parametrize(
+    "raw",
+    [
+        pytest.param("", id="empty"),
+        pytest.param("  ", id="whitespace_only"),
+        pytest.param(None, id="none"),
+        pytest.param(123, id="integer"),
+        pytest.param("unknown_type", id="unknown"),
+        pytest.param("birth_certificate", id="not_in_types"),
+    ],
+)
+def test_resolve_document_type_invalid(raw) -> None:
+    with pytest.raises(DocumentColumnError):
+        _resolve_document_type(raw)
 
-    def test_single_document(self) -> None:
-        row = {
-            "given_name": "Ahmad",
-            "document_1_type": "national_id",
-            "document_1_number": "123456",
-            "document_1_country": "AF",
-        }
-        result = expand_document_columns(row)
-        assert result == {
-            "given_name": "Ahmad",
-            "national_id_document_number": "123456",
-            "national_id_country": "AF",
-        }
 
-    def test_single_document_with_expire_date(self) -> None:
-        row = {
-            "document_1_type": "national_passport",
-            "document_1_number": "P99887",
-            "document_1_country": "AF",
-            "document_1_expire_date": "2030-06-15",
-        }
-        result = expand_document_columns(row)
-        assert result == {
-            "national_passport_document_number": "P99887",
-            "national_passport_country": "AF",
-            "national_passport_expiry_date": "2030-06-15",
-        }
+def test_no_document_columns_returns_unchanged() -> None:
+    row = {"given_name": "Ahmad", "family_name": "Khan", "birth_date": "1990-01-01"}
+    result = expand_document_columns(row)
+    assert result == row
 
-    def test_multiple_documents(self) -> None:
-        row = {
-            "given_name": "Fatima",
-            "document_1_type": "national_id",
-            "document_1_number": "123456",
-            "document_1_country": "AF",
-            "document_2_type": "national_passport",
-            "document_2_number": "98765",
-            "document_2_country": "AF",
-            "document_2_expire_date": "2030-01-01",
-        }
-        result = expand_document_columns(row)
-        assert result == {
-            "given_name": "Fatima",
-            "national_id_document_number": "123456",
-            "national_id_country": "AF",
-            "national_passport_document_number": "98765",
-            "national_passport_country": "AF",
-            "national_passport_expiry_date": "2030-01-01",
-        }
 
-    def test_three_documents_max(self) -> None:
-        row = {
-            "document_1_type": "national_id",
-            "document_1_number": "111",
-            "document_1_country": "AF",
-            "document_2_type": "national_passport",
-            "document_2_number": "222",
-            "document_2_country": "AF",
-            "document_3_type": "national_id",
-            "document_3_number": "333",
-            "document_3_country": "PK",
-        }
-        result = expand_document_columns(row)
-        assert "national_id_document_number" in result
-        assert "national_passport_document_number" in result
+def test_single_document() -> None:
+    row = {
+        "given_name": "Ahmad",
+        "document_1_type": "national_id",
+        "document_1_number": "123456",
+        "document_1_country": "AF",
+    }
+    result = expand_document_columns(row)
+    assert result == {
+        "given_name": "Ahmad",
+        "national_id_document_number": "123456",
+        "national_id_country": "AF",
+    }
 
-    def test_index_exceeds_max_raises(self) -> None:
-        row = {
-            "document_4_type": "national_id",
-            "document_4_number": "123",
-            "document_4_country": "AF",
-        }
-        with pytest.raises(DocumentColumnError, match="exceeds maximum"):
-            expand_document_columns(row)
 
-    def test_empty_type_skips_slot(self) -> None:
-        row = {
-            "given_name": "Omar",
-            "document_1_type": "national_id",
-            "document_1_number": "123",
-            "document_1_country": "AF",
-            "document_2_type": "",
-            "document_2_number": "",
-            "document_2_country": "",
-        }
-        result = expand_document_columns(row)
-        assert result == {
-            "given_name": "Omar",
-            "national_id_document_number": "123",
-            "national_id_country": "AF",
-        }
+def test_single_document_with_expire_date() -> None:
+    row = {
+        "document_1_type": "national_passport",
+        "document_1_number": "P99887",
+        "document_1_country": "AF",
+        "document_1_expire_date": "2030-06-15",
+    }
+    result = expand_document_columns(row)
+    assert result == {
+        "national_passport_document_number": "P99887",
+        "national_passport_country": "AF",
+        "national_passport_expiry_date": "2030-06-15",
+    }
 
-    def test_none_type_skips_slot(self) -> None:
-        row = {
-            "document_1_type": "national_id",
-            "document_1_number": "123",
-            "document_1_country": "AF",
-            "document_2_type": None,
-            "document_2_number": None,
-            "document_2_country": None,
-        }
-        result = expand_document_columns(row)
-        assert result == {
-            "national_id_document_number": "123",
-            "national_id_country": "AF",
-        }
 
-    def test_missing_number_raises(self) -> None:
-        row = {
-            "document_1_type": "national_id",
-            "document_1_country": "AF",
-        }
-        with pytest.raises(DocumentColumnError, match="document_1_number is required"):
-            expand_document_columns(row)
+def test_multiple_documents() -> None:
+    row = {
+        "given_name": "Fatima",
+        "document_1_type": "national_id",
+        "document_1_number": "123456",
+        "document_1_country": "AF",
+        "document_2_type": "national_passport",
+        "document_2_number": "98765",
+        "document_2_country": "AF",
+        "document_2_expire_date": "2030-01-01",
+    }
+    result = expand_document_columns(row)
+    assert result == {
+        "given_name": "Fatima",
+        "national_id_document_number": "123456",
+        "national_id_country": "AF",
+        "national_passport_document_number": "98765",
+        "national_passport_country": "AF",
+        "national_passport_expiry_date": "2030-01-01",
+    }
 
-    def test_missing_country_raises(self) -> None:
-        row = {
-            "document_1_type": "national_id",
-            "document_1_number": "123",
-        }
-        with pytest.raises(DocumentColumnError, match="document_1_country is required"):
-            expand_document_columns(row)
 
-    def test_empty_number_raises(self) -> None:
-        row = {
-            "document_1_type": "national_id",
-            "document_1_number": "",
-            "document_1_country": "AF",
-        }
-        with pytest.raises(DocumentColumnError, match="document_1_number is required"):
-            expand_document_columns(row)
+def test_three_documents_max() -> None:
+    row = {
+        "document_1_type": "national_id",
+        "document_1_number": "111",
+        "document_1_country": "AF",
+        "document_2_type": "national_passport",
+        "document_2_number": "222",
+        "document_2_country": "AF",
+        "document_3_type": "national_id",
+        "document_3_number": "333",
+        "document_3_country": "PK",
+    }
+    result = expand_document_columns(row)
+    assert "national_id_document_number" in result
+    assert "national_passport_document_number" in result
 
-    def test_empty_country_raises(self) -> None:
-        row = {
-            "document_1_type": "national_id",
-            "document_1_number": "123",
-            "document_1_country": "  ",
-        }
-        with pytest.raises(DocumentColumnError, match="document_1_country is required"):
-            expand_document_columns(row)
 
-    def test_optional_expire_date_missing(self) -> None:
-        row = {
-            "document_1_type": "national_id",
-            "document_1_number": "123",
-            "document_1_country": "AF",
-        }
-        result = expand_document_columns(row)
-        assert "national_id_expiry_date" not in result
+def test_index_exceeds_max_raises() -> None:
+    row = {
+        "document_4_type": "national_id",
+        "document_4_number": "123",
+        "document_4_country": "AF",
+    }
+    with pytest.raises(DocumentColumnError, match="exceeds maximum"):
+        expand_document_columns(row)
 
-    def test_optional_expire_date_empty(self) -> None:
-        row = {
-            "document_1_type": "national_id",
-            "document_1_number": "123",
-            "document_1_country": "AF",
-            "document_1_expire_date": "",
-        }
-        result = expand_document_columns(row)
-        assert "national_id_expiry_date" not in result
 
-    def test_optional_expire_date_none(self) -> None:
-        row = {
-            "document_1_type": "national_id",
-            "document_1_number": "123",
-            "document_1_country": "AF",
-            "document_1_expire_date": None,
-        }
-        result = expand_document_columns(row)
-        assert "national_id_expiry_date" not in result
+def test_empty_type_skips_slot() -> None:
+    row = {
+        "given_name": "Omar",
+        "document_1_type": "national_id",
+        "document_1_number": "123",
+        "document_1_country": "AF",
+        "document_2_type": "",
+        "document_2_number": "",
+        "document_2_country": "",
+    }
+    result = expand_document_columns(row)
+    assert result == {
+        "given_name": "Omar",
+        "national_id_document_number": "123",
+        "national_id_country": "AF",
+    }
 
-    def test_preserves_non_document_fields(self) -> None:
-        row = {
-            "given_name": "Test",
-            "family_name": "User",
-            "birth_date": "2000-01-01",
-            "gender": "MALE",
-            "document_1_type": "national_id",
-            "document_1_number": "123",
-            "document_1_country": "AF",
-        }
-        result = expand_document_columns(row)
-        assert result["given_name"] == "Test"
-        assert result["family_name"] == "User"
-        assert result["birth_date"] == "2000-01-01"
-        assert result["gender"] == "MALE"
 
-    def test_numbered_columns_are_removed(self) -> None:
-        row = {
-            "document_1_type": "national_id",
-            "document_1_number": "123",
-            "document_1_country": "AF",
-            "document_1_expire_date": "2030-01-01",
-        }
-        result = expand_document_columns(row)
-        assert "document_1_type" not in result
-        assert "document_1_number" not in result
-        assert "document_1_country" not in result
-        assert "document_1_expire_date" not in result
+def test_none_type_skips_slot() -> None:
+    row = {
+        "document_1_type": "national_id",
+        "document_1_number": "123",
+        "document_1_country": "AF",
+        "document_2_type": None,
+        "document_2_number": None,
+        "document_2_country": None,
+    }
+    result = expand_document_columns(row)
+    assert result == {
+        "national_id_document_number": "123",
+        "national_id_country": "AF",
+    }
 
-    def test_old_prefixed_format_passes_through(self) -> None:
-        row = {
-            "national_id_document_number": "123456",
-            "national_id_country": "AF",
-            "national_passport_document_number": "P99887",
-            "national_passport_country": "AF",
-        }
-        result = expand_document_columns(row)
-        assert result == row
 
-    def test_display_name_type_values(self) -> None:
-        row = {
-            "document_1_type": "National ID",
-            "document_1_number": "123",
-            "document_1_country": "AF",
-            "document_2_type": "National Passport",
-            "document_2_number": "456",
-            "document_2_country": "AF",
-        }
-        result = expand_document_columns(row)
-        assert result == {
-            "national_id_document_number": "123",
-            "national_id_country": "AF",
-            "national_passport_document_number": "456",
-            "national_passport_country": "AF",
-        }
+def test_missing_number_raises() -> None:
+    row = {
+        "document_1_type": "national_id",
+        "document_1_country": "AF",
+    }
+    with pytest.raises(DocumentColumnError, match="document_1_number is required"):
+        expand_document_columns(row)
+
+
+def test_missing_country_raises() -> None:
+    row = {
+        "document_1_type": "national_id",
+        "document_1_number": "123",
+    }
+    with pytest.raises(DocumentColumnError, match="document_1_country is required"):
+        expand_document_columns(row)
+
+
+def test_empty_number_raises() -> None:
+    row = {
+        "document_1_type": "national_id",
+        "document_1_number": "",
+        "document_1_country": "AF",
+    }
+    with pytest.raises(DocumentColumnError, match="document_1_number is required"):
+        expand_document_columns(row)
+
+
+def test_empty_country_raises() -> None:
+    row = {
+        "document_1_type": "national_id",
+        "document_1_number": "123",
+        "document_1_country": "  ",
+    }
+    with pytest.raises(DocumentColumnError, match="document_1_country is required"):
+        expand_document_columns(row)
+
+
+def test_optional_expire_date_missing() -> None:
+    row = {
+        "document_1_type": "national_id",
+        "document_1_number": "123",
+        "document_1_country": "AF",
+    }
+    result = expand_document_columns(row)
+    assert "national_id_expiry_date" not in result
+
+
+def test_optional_expire_date_empty() -> None:
+    row = {
+        "document_1_type": "national_id",
+        "document_1_number": "123",
+        "document_1_country": "AF",
+        "document_1_expire_date": "",
+    }
+    result = expand_document_columns(row)
+    assert "national_id_expiry_date" not in result
+
+
+def test_optional_expire_date_none() -> None:
+    row = {
+        "document_1_type": "national_id",
+        "document_1_number": "123",
+        "document_1_country": "AF",
+        "document_1_expire_date": None,
+    }
+    result = expand_document_columns(row)
+    assert "national_id_expiry_date" not in result
+
+
+def test_preserves_non_document_fields() -> None:
+    row = {
+        "given_name": "Test",
+        "family_name": "User",
+        "birth_date": "2000-01-01",
+        "gender": "MALE",
+        "document_1_type": "national_id",
+        "document_1_number": "123",
+        "document_1_country": "AF",
+    }
+    result = expand_document_columns(row)
+    assert result["given_name"] == "Test"
+    assert result["family_name"] == "User"
+    assert result["birth_date"] == "2000-01-01"
+    assert result["gender"] == "MALE"
+
+
+def test_numbered_columns_are_removed() -> None:
+    row = {
+        "document_1_type": "national_id",
+        "document_1_number": "123",
+        "document_1_country": "AF",
+        "document_1_expire_date": "2030-01-01",
+    }
+    result = expand_document_columns(row)
+    assert "document_1_type" not in result
+    assert "document_1_number" not in result
+    assert "document_1_country" not in result
+    assert "document_1_expire_date" not in result
+
+
+def test_old_prefixed_format_passes_through() -> None:
+    row = {
+        "national_id_document_number": "123456",
+        "national_id_country": "AF",
+        "national_passport_document_number": "P99887",
+        "national_passport_country": "AF",
+    }
+    result = expand_document_columns(row)
+    assert result == row
+
+
+def test_display_name_type_values() -> None:
+    row = {
+        "document_1_type": "National ID",
+        "document_1_number": "123",
+        "document_1_country": "AF",
+        "document_2_type": "National Passport",
+        "document_2_number": "456",
+        "document_2_country": "AF",
+    }
+    result = expand_document_columns(row)
+    assert result == {
+        "national_id_document_number": "123",
+        "national_id_country": "AF",
+        "national_passport_document_number": "456",
+        "national_passport_country": "AF",
+    }


### PR DESCRIPTION
[AB#303584](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/303584)

## Title
Support numbered document columns (document_X_type/number/country) in Excel import

## Motivation
CO's suggest that where there is multiple documents for the beneficiaries, the payment plan excel file downloaded should have the document numbers in one column and another column to have the type of id. This will eliminate the payment plan excel file having multiple columns for the multiple documents

## Summary
- Add a new expand_document_columns pre-processor that converts numbered document columns (document_1_type, document_1_number, document_1_country, document_1_expire_date) into the existing type-prefixed flex-field format (national_id_document_number, national_id_country, national_id_expiry_date)
- The old prefixed column format continues to work unchanged (backward compatible)

Import document file sample:
https://docs.google.com/spreadsheets/d/1as2M7elZeHG5_X6qKEnXKrtncz-ikRSmm-rRPbYTYHM/edit?usp=sharing