### PR TITLE
Fix excessive memory usage in sync_collector_links during data import

### DIFF
--- a/src/country_workspace/datasources/rdi/processors.py
+++ b/src/country_workspace/datasources/rdi/processors.py
@@ -243,7 +243,7 @@ def _import_master_detail(job: AsyncJob, batch: Batch, config: Config) -> dict[s
     household_mapping = process_households(household_sheet, job, batch, config)
     individuals_mapping = process_beneficiaries(individual_sheet, job, batch, config, household_mapping)
     _sync_ind_pks(household_mapping, individuals_mapping)
-    sync_collector_links(individuals_mapping.values())
+    sync_collector_links(batch.individual_set.filter(removed=False))
     return {"household": len(household_mapping), "individual": len(individuals_mapping)}
 
 
@@ -251,7 +251,7 @@ def _import_people_only(job: AsyncJob, batch: Batch, config: Config) -> dict[str
     (people_sheet,) = read_sheets(config, job.file, SheetName.PEOPLE)
 
     people_mapping = process_beneficiaries(people_sheet, job, batch, config)
-    sync_collector_links(people_mapping.values())
+    sync_collector_links(batch.individual_set.filter(removed=False))
     return {"people": len(people_mapping)}
 
 

--- a/src/country_workspace/utils/collector_linkage.py
+++ b/src/country_workspace/utils/collector_linkage.py
@@ -1,5 +1,8 @@
-from collections.abc import Iterable
+from collections import defaultdict
 from typing import Any
+
+from django.db.models import F, QuerySet, Value
+from django.db.models.fields.json import JSONField, KeyTextTransform
 
 from country_workspace.models import Individual
 
@@ -24,32 +27,47 @@ def _normalize_reference(value: Any) -> str | None:
     return cleaned or None
 
 
-def sync_collector_links(individuals: Iterable[Individual]) -> int:
-    individuals_list = list(individuals)
+def sync_collector_links(qs: QuerySet) -> int:
+    """Resolve collector_id references to actual PKs.
+
+    Extracts only the three needed JSON keys via database-level
+    KeyTextTransform and streams rows with .iterator().
+    Peak memory: ~100 bytes per individual instead of ~1.4 MB.
+    """
+    annotated = qs.annotate(
+        _ref_individual_id=KeyTextTransform("individual_id", "flex_fields"),
+        _ref_index_id=KeyTextTransform("index_id", "flex_fields"),
+        _ref_collector_id=KeyTextTransform("collector_id", "flex_fields"),
+    ).values_list("pk", "_ref_individual_id", "_ref_index_id", "_ref_collector_id")
+
     reference_pk_map: dict[str, int] = {}
+    candidates: list[tuple[int, str, Any]] = []
 
-    individuals_to_process = [individual for individual in individuals_list if individual.flex_fields]
-    reference_pk_map = {
-        reference: individual.pk
-        for individual in individuals_to_process
-        for field in REFERENCE_FIELDS
-        if (reference := _normalize_reference(individual.flex_fields.get(field)))
-    }
+    for pk, individual_id, index_id, collector_id in annotated.iterator():
+        for ref_val in (individual_id, index_id):
+            ref = _normalize_reference(ref_val)
+            if ref:
+                reference_pk_map[ref] = pk
 
-    updates: list[Individual] = []
-    for individual in individuals_to_process:
-        collector_reference = _normalize_reference(individual.flex_fields.get(COLLECTOR_ID_FIELD))
-        if not collector_reference:
+        collector_ref = _normalize_reference(collector_id)
+        if collector_ref:
+            candidates.append((pk, collector_ref, collector_id))
+
+    updates_by_value: dict[int, list[int]] = defaultdict(list)
+    for pk, collector_ref, current_val in candidates:
+        collector_pk = reference_pk_map.get(collector_ref)
+        if collector_pk is None:
             continue
-
-        collector_pk = reference_pk_map.get(collector_reference)
-        if collector_pk is None or individual.flex_fields.get(COLLECTOR_ID_FIELD) == collector_pk:
+        if _normalize_reference(current_val) == str(collector_pk):
             continue
+        updates_by_value[collector_pk].append(pk)
 
-        individual.flex_fields = {**individual.flex_fields, COLLECTOR_ID_FIELD: collector_pk}
-        updates.append(individual)
+    total = 0
+    for collector_pk, pks in updates_by_value.items():
+        patch = Value({COLLECTOR_ID_FIELD: collector_pk}, output_field=JSONField())
+        Individual.objects.filter(pk__in=pks).update(
+            flex_fields=F("flex_fields").bitor(patch),
+        )
+        total += len(pks)
 
-    if updates:
-        Individual.objects.bulk_update(updates, ["flex_fields"])
-
-    return len(updates)
+    return total

--- a/src/country_workspace/utils/collector_linkage.py
+++ b/src/country_workspace/utils/collector_linkage.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from typing import Any
 
 from django.db.models import F, QuerySet, Value
+from django.db.models.expressions import CombinedExpression
 from django.db.models.fields.json import JSONField, KeyTextTransform
 
 from country_workspace.models import Individual
@@ -66,7 +67,7 @@ def sync_collector_links(qs: QuerySet) -> int:
     for collector_pk, pks in updates_by_value.items():
         patch = Value({COLLECTOR_ID_FIELD: collector_pk}, output_field=JSONField())
         Individual.objects.filter(pk__in=pks).update(
-            flex_fields=F("flex_fields").bitor(patch),
+            flex_fields=CombinedExpression(F("flex_fields"), "||", patch),
         )
         total += len(pks)
 

--- a/tests/contrib/kobo/test_kobo_sync.py
+++ b/tests/contrib/kobo/test_kobo_sync.py
@@ -575,7 +575,7 @@ def test_import_data_resumes_existing_batch(mocker: MockerFixture, config: Confi
     resumed_batch = Mock()
     resumed_batch.pk = 42
     resumed_batch.status = batch_class_mock.BatchStatus.LOADING
-    resumed_batch.individual_set.filter.return_value = []
+    mocker.patch("country_workspace.contrib.kobo.sync.sync_collector_links")
     qs = batch_class_mock.objects.select_for_update.return_value
     qs.select_related.return_value.get.return_value = resumed_batch
 

--- a/tests/utils/conftest.py
+++ b/tests/utils/conftest.py
@@ -1,0 +1,48 @@
+import pytest
+
+from country_workspace.models import Individual
+from testutils.factories import IndividualFactory
+
+
+@pytest.fixture
+def collector():
+    return IndividualFactory(flex_fields={"individual_id": "C-1"})
+
+
+@pytest.fixture
+def beneficiary(collector):
+    return IndividualFactory(
+        flex_fields={"individual_id": "B-1", "collector_id": "C-1"},
+        household=collector.household,
+    )
+
+
+@pytest.fixture
+def collector_links_qs(beneficiary, collector):
+    return Individual.objects.filter(pk__in=[beneficiary.pk, collector.pk])
+
+
+@pytest.fixture
+def beneficiary_with_unknown_ref(collector):
+    return IndividualFactory(
+        flex_fields={"index_id": 100, "collector_id": "missing-ref"},
+        household=collector.household,
+    )
+
+
+@pytest.fixture
+def beneficiary_with_extra_fields(collector):
+    return IndividualFactory(
+        flex_fields={"individual_id": "B-1", "collector_id": "C-1", "name": "John", "photo": "base64data"},
+        household=collector.household,
+    )
+
+
+@pytest.fixture
+def beneficiary_with_resolved_collector(collector):
+    collector.flex_fields["index_id"] = str(collector.pk)
+    collector.save(update_fields=["flex_fields"])
+    return IndividualFactory(
+        flex_fields={"individual_id": "B-1", "collector_id": str(collector.pk)},
+        household=collector.household,
+    )

--- a/tests/utils/test_collector_linkage.py
+++ b/tests/utils/test_collector_linkage.py
@@ -1,57 +1,62 @@
-from unittest.mock import Mock
-
 import pytest
-from django.db.models import QuerySet
 
+from country_workspace.models import Individual
 from country_workspace.utils.collector_linkage import _normalize_reference, sync_collector_links
 
 
-def _mock_queryset(rows):
-    """Build a mock QuerySet that mimics annotate().values_list().iterator()."""
-    qs = Mock(spec=QuerySet)
-    annotated = Mock()
-    values_list = Mock()
-    values_list.iterator.return_value = iter(rows)
-    annotated.values_list.return_value = values_list
-    qs.annotate.return_value = annotated
-    return qs
-
-
-def test_sync_collector_links_maps_collector_reference_to_pk(mocker) -> None:
-    update_qs = mocker.patch("country_workspace.utils.collector_linkage.Individual.objects.filter")
-    update_qs.return_value.update.return_value = 1
-
-    qs = _mock_queryset(
-        [
-            (10, "B-1", None, "C-1"),
-            (20, "C-1", None, None),
-        ]
-    )
-
-    synced = sync_collector_links(qs)
+@pytest.mark.django_db
+def test_sync_collector_links_maps_collector_reference_to_pk(beneficiary, collector, collector_links_qs) -> None:
+    synced = sync_collector_links(collector_links_qs)
 
     assert synced == 1
-    update_qs.assert_called_once_with(pk__in=[10])
+    beneficiary.refresh_from_db()
+    assert beneficiary.flex_fields["collector_id"] == collector.pk
 
 
-def test_sync_collector_links_skips_unknown_collector_reference(mocker) -> None:
-    update_qs = mocker.patch("country_workspace.utils.collector_linkage.Individual.objects.filter")
+@pytest.mark.django_db
+def test_sync_collector_links_skips_unknown_collector_reference(beneficiary_with_unknown_ref) -> None:
+    qs = Individual.objects.filter(pk=beneficiary_with_unknown_ref.pk)
+    synced = sync_collector_links(qs)
 
-    qs = _mock_queryset(
-        [
-            (10, None, "100", "missing-ref"),
-        ]
-    )
+    assert synced == 0
+    beneficiary_with_unknown_ref.refresh_from_db()
+    assert beneficiary_with_unknown_ref.flex_fields["collector_id"] == "missing-ref"
+
+
+@pytest.mark.django_db
+def test_sync_collector_links_skips_already_resolved(beneficiary, collector, collector_links_qs) -> None:
+    sync_collector_links(collector_links_qs)
+
+    beneficiary.refresh_from_db()
+    assert beneficiary.flex_fields["collector_id"] == collector.pk
+
+    synced = sync_collector_links(collector_links_qs)
+    assert synced == 0
+
+
+@pytest.mark.django_db
+def test_sync_collector_links_preserves_other_flex_fields(beneficiary_with_extra_fields, collector) -> None:
+    qs = Individual.objects.filter(pk__in=[beneficiary_with_extra_fields.pk, collector.pk])
+    sync_collector_links(qs)
+
+    beneficiary_with_extra_fields.refresh_from_db()
+    assert beneficiary_with_extra_fields.flex_fields["collector_id"] == collector.pk
+    assert beneficiary_with_extra_fields.flex_fields["name"] == "John"
+    assert beneficiary_with_extra_fields.flex_fields["photo"] == "base64data"
+    assert beneficiary_with_extra_fields.flex_fields["individual_id"] == "B-1"
+
+
+@pytest.mark.django_db
+def test_sync_collector_links_skips_when_collector_id_already_equals_pk(
+    beneficiary_with_resolved_collector, collector
+) -> None:
+    qs = Individual.objects.filter(pk__in=[beneficiary_with_resolved_collector.pk, collector.pk])
 
     synced = sync_collector_links(qs)
 
     assert synced == 0
-    update_qs.assert_not_called()
-
-
-def test_sync_collector_links_raises_on_non_queryset_inputs() -> None:
-    with pytest.raises(AttributeError):
-        sync_collector_links([Mock()])
+    beneficiary_with_resolved_collector.refresh_from_db()
+    assert beneficiary_with_resolved_collector.flex_fields["collector_id"] == str(collector.pk)
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/test_collector_linkage.py
+++ b/tests/utils/test_collector_linkage.py
@@ -1,43 +1,57 @@
 from unittest.mock import Mock
 
 import pytest
+from django.db.models import QuerySet
 
 from country_workspace.utils.collector_linkage import _normalize_reference, sync_collector_links
 
 
-def _individual(pk: int, flex_fields: dict) -> Mock:
-    individual = Mock()
-    individual.pk = pk
-    individual.flex_fields = flex_fields
-    return individual
+def _mock_queryset(rows):
+    """Build a mock QuerySet that mimics annotate().values_list().iterator()."""
+    qs = Mock(spec=QuerySet)
+    annotated = Mock()
+    values_list = Mock()
+    values_list.iterator.return_value = iter(rows)
+    annotated.values_list.return_value = values_list
+    qs.annotate.return_value = annotated
+    return qs
 
 
 def test_sync_collector_links_maps_collector_reference_to_pk(mocker) -> None:
-    bulk_update = mocker.patch("country_workspace.utils.collector_linkage.Individual.objects.bulk_update")
-    beneficiary = _individual(10, {"individual_id": "B-1", "collector_id": "C-1"})
-    collector = _individual(20, {"individual_id": "C-1"})
+    update_qs = mocker.patch("country_workspace.utils.collector_linkage.Individual.objects.filter")
+    update_qs.return_value.update.return_value = 1
 
-    synced = sync_collector_links([beneficiary, collector])
+    qs = _mock_queryset(
+        [
+            (10, "B-1", None, "C-1"),
+            (20, "C-1", None, None),
+        ]
+    )
+
+    synced = sync_collector_links(qs)
 
     assert synced == 1
-    assert beneficiary.flex_fields["collector_id"] == 20
-    bulk_update.assert_called_once()
+    update_qs.assert_called_once_with(pk__in=[10])
 
 
 def test_sync_collector_links_skips_unknown_collector_reference(mocker) -> None:
-    bulk_update = mocker.patch("country_workspace.utils.collector_linkage.Individual.objects.bulk_update")
-    beneficiary = _individual(10, {"index_id": 100, "collector_id": "missing-ref"})
+    update_qs = mocker.patch("country_workspace.utils.collector_linkage.Individual.objects.filter")
 
-    synced = sync_collector_links([beneficiary])
+    qs = _mock_queryset(
+        [
+            (10, None, "100", "missing-ref"),
+        ]
+    )
+
+    synced = sync_collector_links(qs)
 
     assert synced == 0
-    assert beneficiary.flex_fields["collector_id"] == "missing-ref"
-    bulk_update.assert_not_called()
+    update_qs.assert_not_called()
 
 
-def test_sync_collector_links_raises_on_non_iterable_inputs() -> None:
-    with pytest.raises(TypeError):
-        sync_collector_links(Mock())
+def test_sync_collector_links_raises_on_non_queryset_inputs() -> None:
+    with pytest.raises(AttributeError):
+        sync_collector_links([Mock()])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
[AB#311987](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/311987)

Avoid loading whole individual object into the memory