### PR TITLE
Improve flex fields sync

### DIFF
--- a/src/country_workspace/admin/sync_log.py
+++ b/src/country_workspace/admin/sync_log.py
@@ -1,9 +1,15 @@
 from admin_extra_buttons.decorators import button
-from django.contrib import admin
+from django.contrib import admin, messages
 from django.http import HttpRequest, HttpResponse
+from django.utils.translation import gettext as _
+from strategy_field.utils import fqn
 
-from ..models import SyncLog
+from ..models import AsyncJob, SyncLog
 from .base import BaseModelAdmin
+
+
+def sync_flex_fields_task(job: AsyncJob) -> None:
+    SyncLog.objects.refresh()
 
 
 @admin.register(SyncLog)
@@ -13,4 +19,14 @@ class SyncLogAdmin(BaseModelAdmin):
 
     @button(permission="country_workspace.can_synchronize")
     def sync_flex_fields(self, request: HttpRequest) -> "HttpResponse":
-        SyncLog.objects.refresh()
+        AsyncJob.objects.create(
+            description="Sync Flex Fields",
+            program=None,
+            owner=request.user,
+            type=AsyncJob.JobType.TASK,
+            action=fqn(sync_flex_fields_task),
+            batch=None,
+            file=None,
+            config={},
+        ).queue()
+        self.message_user(request, _("Flex fields sync has been scheduled."), level=messages.SUCCESS)

--- a/src/country_workspace/models/sync.py
+++ b/src/country_workspace/models/sync.py
@@ -17,8 +17,11 @@ if TYPE_CHECKING:
 
 class SyncManager(BaseManager):
     def refresh(self) -> None:
-        for record in self.all():
-            record.refresh()
+        from country_workspace.signals import collect_invalidations
+
+        with collect_invalidations():
+            for record in self.all():
+                record.refresh()
 
     def create_lookups(self) -> None:
         from hope_flex_fields.models import FieldDefinition
@@ -77,8 +80,10 @@ class SyncLog(BaseModel):
         client = HopeClient()
         choices = list(client.get_lookup(self.data["remote_url"]).items())
         for obj in (fd, *FlexField.objects.filter(definition=fd)):
-            obj.attrs = {**(obj.attrs or {}), "choices": choices}
-            obj.save(update_fields=["attrs"])
+            new_attrs = {**(obj.attrs or {}), "choices": choices}
+            if new_attrs != obj.attrs:
+                obj.attrs = new_attrs
+                obj.save(update_fields=["attrs"])
 
         self.last_update_date = timezone.now()
         self.save(update_fields=["last_update_date"])

--- a/src/country_workspace/signals.py
+++ b/src/country_workspace/signals.py
@@ -1,3 +1,6 @@
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import Any
 
 from django.db.models import Q
@@ -8,12 +11,27 @@ from hope_flex_fields.models import DataChecker, DataCheckerFieldset, Fieldset, 
 from country_workspace.models import Program
 from country_workspace.workspaces.models import CountryProgram
 
+_invalidation_state = threading.local()
+
+
+@contextmanager
+def collect_invalidations() -> Iterator[None]:
+    _invalidation_state.deferred_program_pks = set()
+    try:
+        yield
+    finally:
+        program_pks = _invalidation_state.deferred_program_pks
+        _invalidation_state.deferred_program_pks = None
+        for program in Program.objects.filter(pk__in=program_pks):
+            _process_program(program=program)
+
 
 def _get_dc_associated_programs(dc: DataChecker) -> Any:
     return Program.objects.filter(Q(household_checker=dc) | Q(individual_checker=dc))
 
 
 def _invalidate_qs(qs: Any) -> None:
+    qs = qs.filter(last_checked__isnull=False)
     batch_size = 500
     pks = list(qs.values_list("pk", flat=True))
 
@@ -32,6 +50,11 @@ def _process_program(program: Program) -> None:
 
 def _process_datachecker_change(dc: DataChecker) -> None:
     if not (programs := _get_dc_associated_programs(dc=dc)):
+        return
+
+    deferred = getattr(_invalidation_state, "deferred_program_pks", None)
+    if deferred is not None:
+        deferred.update(programs.values_list("pk", flat=True))
         return
 
     for program in programs:

--- a/tests/admin/test_admin_sync_log.py
+++ b/tests/admin/test_admin_sync_log.py
@@ -1,0 +1,39 @@
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from django.urls import reverse
+from strategy_field.utils import fqn
+
+from country_workspace.admin.sync_log import sync_flex_fields_task
+from country_workspace.models import AsyncJob, SyncLog
+
+if TYPE_CHECKING:
+    from django_webtest.pytest_plugin import MixinWithInstanceVariables
+    from testutils.types import CWTestApp
+    from country_workspace.models import User
+
+
+@pytest.fixture
+def app(django_app_factory: "MixinWithInstanceVariables", admin_user: "User") -> "CWTestApp":
+    django_app = django_app_factory(csrf_checks=False)
+    django_app.set_user(admin_user)
+    return django_app
+
+
+def test_sync_flex_fields_creates_async_job(app: "CWTestApp"):
+    url = reverse("admin:country_workspace_synclog_sync_flex_fields")
+    response = app.get(url)
+
+    assert response.status_code == 302
+    job = AsyncJob.objects.latest("pk")
+    assert job.description == "Sync Flex Fields"
+    assert job.type == AsyncJob.JobType.TASK
+    assert job.action == fqn(sync_flex_fields_task)
+    assert job.program is None
+
+
+def test_sync_flex_fields_task_calls_refresh():
+    with patch.object(SyncLog.objects, "refresh") as mock_refresh:
+        sync_flex_fields_task(job=None)
+        mock_refresh.assert_called_once()

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import pytest
+from django.utils import timezone
 from hope_flex_fields.models import DataChecker
 from hope_flex_fields.models import DataCheckerFieldset
 from strategy_field.utils import fqn
@@ -13,6 +14,7 @@ from country_workspace.contrib.hope.constants import (
 from country_workspace.contrib.hope.validators import FullHouseholdValidator
 from country_workspace.signals import (
     _process_datachecker_change,
+    collect_invalidations,
     invalidate_entities_on_datachecker_change,
 )
 from country_workspace.validators.registry import NoopValidator
@@ -21,11 +23,14 @@ from tests.extras.testutils.factories import (
     BatchFactory,
     HouseholdFactory,
     IndividualFactory,
+    FieldDefinitionFactory,
     FieldsetFactory,
     FlexFieldFactory,
 )
 from tests.extras.testutils.factories.program import BeneficiaryGroupFactory
 from tests.extras.testutils.factories.smart_fields import DataCheckerFactory
+
+CHECKED = timezone.now()
 
 
 @pytest.fixture
@@ -49,67 +54,135 @@ def program(hh_datachecker, ind_datachecker):
 
 
 @pytest.fixture
-def households(program):
-    batch = BatchFactory.create(program=program)
-    HouseholdFactory.create_batch(10, batch=batch, errors={}, removed=False)
-    HouseholdFactory.create_batch(10, batch=batch, removed=True)
-    HouseholdFactory.create_batch(10, batch=batch, errors={"some_error": "details"})
+def batch(program):
+    return BatchFactory.create(program=program)
 
 
 @pytest.fixture
-def individuals(program):
-    batch = BatchFactory.create(program=program)
+def households(batch):
+    HouseholdFactory.create_batch(10, batch=batch, errors={}, removed=False, last_checked=CHECKED)
+    HouseholdFactory.create_batch(10, batch=batch, removed=True, last_checked=CHECKED)
+    HouseholdFactory.create_batch(10, batch=batch, errors={"some_error": "details"}, last_checked=CHECKED)
+
+
+@pytest.fixture
+def individuals(batch):
     hh = HouseholdFactory.create(batch=batch, individuals=[])
-    IndividualFactory.create_batch(10, household=hh, errors={}, removed=False)
-    IndividualFactory.create_batch(10, household=hh, removed=True)
-    IndividualFactory.create_batch(10, household=hh, errors={"some_error": "details"})
+    IndividualFactory.create_batch(10, household=hh, errors={}, removed=False, last_checked=CHECKED)
+    IndividualFactory.create_batch(10, household=hh, removed=True, last_checked=CHECKED)
+    IndividualFactory.create_batch(10, household=hh, errors={"some_error": "details"}, last_checked=CHECKED)
 
 
-def test_process_datachecker_change_updates_households(hh_datachecker):
+@pytest.fixture
+def unchecked_households(batch):
+    return HouseholdFactory.create_batch(3, batch=batch, errors={}, removed=False, individuals=[], last_checked=None)
+
+
+@pytest.fixture
+def unchecked_individuals(batch, unchecked_households):
+    return IndividualFactory.create_batch(
+        3, batch=batch, household=unchecked_households[0], errors={}, removed=False, last_checked=None
+    )
+
+
+@pytest.fixture
+def checked_household(batch):
+    return HouseholdFactory.create(batch=batch, errors={}, removed=False, individuals=[], last_checked=CHECKED)
+
+
+@pytest.fixture
+def checked_individual(batch, checked_household):
+    return IndividualFactory.create(
+        batch=batch, household=checked_household, errors={}, removed=False, last_checked=CHECKED
+    )
+
+
+@pytest.fixture
+def hh_validated_households(hh_datachecker):
     program = ProgramFactory.create(household_checker=hh_datachecker)
     batch = BatchFactory.create(program=program)
-    valid = HouseholdFactory.create_batch(3, batch=batch, errors={}, removed=False, individuals=[])
-    HouseholdFactory.create(batch=batch, errors={"x": 1}, removed=False, individuals=[])
-    HouseholdFactory.create(batch=batch, errors={}, removed=True, individuals=[])
+    validated = HouseholdFactory.create_batch(
+        3, batch=batch, errors={}, removed=False, individuals=[], last_checked=CHECKED
+    )
+    HouseholdFactory.create(batch=batch, errors={"x": 1}, removed=False, individuals=[], last_checked=CHECKED)
+    HouseholdFactory.create(batch=batch, errors={}, removed=True, individuals=[], last_checked=CHECKED)
+    return validated
 
+
+def test_process_datachecker_change_updates_households(hh_datachecker, hh_validated_households):
     _process_datachecker_change(hh_datachecker)
 
-    for hh in valid:
+    for hh in hh_validated_households:
         hh.refresh_from_db()
         assert hh.errors == {"data_checker": "Invalidated due to DataChecker change."}
         assert hh.last_checked is None
 
 
-def test_process_datachecker_change_updates_individuals(ind_datachecker):
+@pytest.fixture
+def ind_validated_individuals(ind_datachecker):
     program = ProgramFactory.create(individual_checker=ind_datachecker)
     batch = BatchFactory.create(program=program)
     hh = HouseholdFactory.create(batch=batch, individuals=[])
-    valid = IndividualFactory.create_batch(3, household=hh, errors={}, removed=False)
-    ind_1 = IndividualFactory.create(household=hh, errors={"x": 1}, removed=False)
-    IndividualFactory.create(household=hh, errors={}, removed=True)
+    validated = IndividualFactory.create_batch(3, household=hh, errors={}, removed=False, last_checked=CHECKED)
+    ind_1 = IndividualFactory.create(household=hh, errors={"x": 1}, removed=False, last_checked=CHECKED)
+    IndividualFactory.create(household=hh, errors={}, removed=True, last_checked=CHECKED)
+    return [*validated, ind_1]
 
+
+def test_process_datachecker_change_updates_individuals(ind_datachecker, ind_validated_individuals):
     _process_datachecker_change(ind_datachecker)
 
-    for ind in [*valid, ind_1]:
+    for ind in ind_validated_individuals:
         ind.refresh_from_db()
         assert ind.errors == {"data_checker": "Invalidated due to DataChecker change."}
         assert ind.last_checked is None
 
 
-def test_process_datachecker_change_updates_people(people_datachecker):
+@pytest.fixture
+def people_validated_individuals(people_datachecker):
     bg = BeneficiaryGroupFactory(master_detail=False)
     program = ProgramFactory.create(individual_checker=people_datachecker, beneficiary_group=bg)
     batch = BatchFactory.create(program=program)
-    valid = IndividualFactory.create_batch(3, batch=batch, household=None, errors={}, removed=False)
-    ind_1 = IndividualFactory.create(batch=batch, household=None, errors={"x": 1}, removed=False)
-    IndividualFactory.create(batch=batch, household=None, errors={}, removed=True)
+    validated = IndividualFactory.create_batch(
+        3, batch=batch, household=None, errors={}, removed=False, last_checked=CHECKED
+    )
+    ind_1 = IndividualFactory.create(batch=batch, household=None, errors={"x": 1}, removed=False, last_checked=CHECKED)
+    IndividualFactory.create(batch=batch, household=None, errors={}, removed=True, last_checked=CHECKED)
+    return [*validated, ind_1]
 
+
+def test_process_datachecker_change_updates_people(people_datachecker, people_validated_individuals):
     _process_datachecker_change(people_datachecker)
 
-    for ind in [*valid, ind_1]:
+    for ind in people_validated_individuals:
         ind.refresh_from_db()
         assert ind.errors == {"data_checker": "Invalidated due to DataChecker change."}
         assert ind.last_checked is None
+
+
+def test_non_validated_entities_are_not_invalidated(
+    hh_datachecker, ind_datachecker, unchecked_households, unchecked_individuals, checked_household, checked_individual
+):
+    _process_datachecker_change(hh_datachecker)
+    _process_datachecker_change(ind_datachecker)
+
+    for hh in unchecked_households:
+        hh.refresh_from_db()
+        assert hh.errors == {}
+        assert hh.last_checked is None
+
+    for ind in unchecked_individuals:
+        ind.refresh_from_db()
+        assert ind.errors == {}
+        assert ind.last_checked is None
+
+    checked_household.refresh_from_db()
+    assert checked_household.errors == {"data_checker": "Invalidated due to DataChecker change."}
+    assert checked_household.last_checked is None
+
+    checked_individual.refresh_from_db()
+    assert checked_individual.errors == {"data_checker": "Invalidated due to DataChecker change."}
+    assert checked_individual.last_checked is None
 
 
 def test_process_datachecker_change_ignores_unknown_checker_name():
@@ -117,24 +190,39 @@ def test_process_datachecker_change_ignores_unknown_checker_name():
     _process_datachecker_change(dc)
 
 
-def test_fieldset_update_triggers_processing(hh_datachecker):
+@pytest.fixture
+def hh_fieldsets(hh_datachecker):
     fs = FieldsetFactory.create()
     fs_2 = FieldsetFactory.create()
     hh_datachecker.fieldsets.add(*[fs, fs_2])
+    return fs, fs_2
 
+
+@pytest.fixture
+def ind_dcfieldset(ind_datachecker):
+    fs = FieldsetFactory.create()
+    return DataCheckerFieldset.objects.create(checker=ind_datachecker, fieldset=fs)
+
+
+@pytest.fixture
+def hh_flexfield(hh_datachecker):
+    fs = FieldsetFactory.create()
+    hh_datachecker.fieldsets.add(fs)
+    return FlexFieldFactory.create(fieldset=fs)
+
+
+def test_fieldset_update_triggers_processing(hh_datachecker, hh_fieldsets):
+    fs, _ = hh_fieldsets
     with patch("country_workspace.signals._process_datachecker_change") as mocked:
         fs.description = "Updated"
         fs.save(update_fields=["description"])
         mocked.assert_called_once_with(dc=hh_datachecker)
 
 
-def test_dcfieldset_update_triggers_processing(ind_datachecker):
-    fs = FieldsetFactory.create()
-    rel = DataCheckerFieldset.objects.create(checker=ind_datachecker, fieldset=fs)
-
+def test_dcfieldset_update_triggers_processing(ind_datachecker, ind_dcfieldset):
     with patch("country_workspace.signals._process_datachecker_change") as mocked:
-        rel.prefix = "p_"
-        rel.save(update_fields=["prefix"])
+        ind_dcfieldset.prefix = "p_"
+        ind_dcfieldset.save(update_fields=["prefix"])
         mocked.assert_called_once_with(dc=ind_datachecker)
 
 
@@ -145,14 +233,10 @@ def test_datachecker_update_triggers_processing(hh_datachecker):
         mocked.assert_called_once_with(dc=hh_datachecker)
 
 
-def test_flexfield_update_triggers_processing(hh_datachecker):
-    fs = FieldsetFactory.create()
-    hh_datachecker.fieldsets.add(fs)
-    ff = FlexFieldFactory.create(fieldset=fs)
-
+def test_flexfield_update_triggers_processing(hh_datachecker, hh_flexfield):
     with patch("country_workspace.signals._process_datachecker_change") as mocked:
-        ff.attrs = {"label": "Updated"}
-        ff.save(update_fields=["attrs"])
+        hh_flexfield.attrs = {"label": "Updated"}
+        hh_flexfield.save(update_fields=["attrs"])
         mocked.assert_called_once_with(dc=hh_datachecker)
 
 
@@ -180,22 +264,29 @@ def test_invalidation_on_individual_checker_change(program, individuals):
     _test_invalidation_on_checker_change(program, IndividualFactory, checker_field="individual_checker")
 
 
-def test_invalidation_on_beneficiary_validator_change(hh_datachecker, ind_datachecker):
+@pytest.fixture
+def validator_change_program(hh_datachecker, ind_datachecker):
     program = ProgramFactory.create(
         household_checker=hh_datachecker, individual_checker=ind_datachecker, beneficiary_validator=fqn(NoopValidator)
     )
     batch = BatchFactory.create(program=program)
-    valid_hhs = HouseholdFactory.create_batch(3, batch=batch, individuals=[])
-    HouseholdFactory.create_batch(4, batch=batch, individuals=[], errors={"x": 1}, removed=False)
-    HouseholdFactory.create_batch(5, batch=batch, individuals=[], removed=True)
+    valid_hhs = HouseholdFactory.create_batch(3, batch=batch, individuals=[], last_checked=CHECKED)
+    HouseholdFactory.create_batch(4, batch=batch, individuals=[], errors={"x": 1}, removed=False, last_checked=CHECKED)
+    HouseholdFactory.create_batch(5, batch=batch, individuals=[], removed=True, last_checked=CHECKED)
 
     for hh in valid_hhs:
-        IndividualFactory.create_batch(3, batch=batch, household=hh, errors={}, removed=False)
-        IndividualFactory.create_batch(4, batch=batch, household=hh, errors={"x": 1}, removed=False)
-        IndividualFactory.create_batch(5, batch=batch, household=hh, errors={}, removed=True)
+        IndividualFactory.create_batch(3, batch=batch, household=hh, errors={}, removed=False, last_checked=CHECKED)
+        IndividualFactory.create_batch(
+            4, batch=batch, household=hh, errors={"x": 1}, removed=False, last_checked=CHECKED
+        )
+        IndividualFactory.create_batch(5, batch=batch, household=hh, errors={}, removed=True, last_checked=CHECKED)
 
-    program.beneficiary_validator = fqn(FullHouseholdValidator)
-    program.save()
+    return program
+
+
+def test_invalidation_on_beneficiary_validator_change(validator_change_program):
+    validator_change_program.beneficiary_validator = fqn(FullHouseholdValidator)
+    validator_change_program.save()
 
     hh_invalidated_count = 0
     ind_invalidated_count = 0
@@ -214,19 +305,110 @@ def test_invalidation_on_beneficiary_validator_change(hh_datachecker, ind_datach
             ind_invalidated_count += 1
 
     assert hh_invalidated_count == 7
-    assert ind_invalidated_count == 7 * 3  # 7 invalid across 3 valid households
+    assert ind_invalidated_count == 7 * 3
 
 
-def test_no_invalidation_on_other_field_change(program):
-    batch = BatchFactory.create(program=program)
-    HouseholdFactory.create_batch(10, batch=batch, individuals=[], errors={"x": "1"}, removed=False)
+@pytest.fixture
+def households_with_errors(batch):
+    return HouseholdFactory.create_batch(
+        10, batch=batch, individuals=[], errors={"x": "1"}, removed=False, last_checked=CHECKED
+    )
 
+
+def test_no_invalidation_on_other_field_change(program, households_with_errors):
     program.name = "New Program Name"
     program.save()
 
-    for hh in HouseholdFactory._meta.model.objects.all():
+    for hh in households_with_errors:
         hh.refresh_from_db()
         assert hh.errors == {"x": "1"}
+
+
+@pytest.fixture
+def synclog_for_refresh():
+    from country_workspace.models import SyncLog
+    from hope_flex_fields.models import FieldDefinition
+    from django.contrib.contenttypes.models import ContentType
+
+    fd = FieldDefinitionFactory.create(name="test-fd", attrs={"choices": [["x", "X"]]})
+    fd.refresh_from_db()
+    fs = FieldsetFactory.create()
+    ff = FlexFieldFactory.create(fieldset=fs, definition=fd, attrs={})
+    ff.refresh_from_db()
+    ct = ContentType.objects.get_for_model(FieldDefinition)
+    sync = SyncLog.objects.create(content_type=ct, object_id=fd.pk, data={"remote_url": "lookups/test"})
+    return sync, fd, ff
+
+
+def test_collect_invalidations_deduplicates_and_flushes(hh_datachecker):
+    program = ProgramFactory.create(household_checker=hh_datachecker)
+    batch = BatchFactory.create(program=program)
+    hh = HouseholdFactory.create(batch=batch, errors={}, removed=False, individuals=[], last_checked=CHECKED)
+
+    with collect_invalidations():
+        _process_datachecker_change(hh_datachecker)
+        _process_datachecker_change(hh_datachecker)
+
+        hh.refresh_from_db()
+        assert hh.last_checked == CHECKED
+
+    hh.refresh_from_db()
+    assert hh.last_checked is None
+    assert hh.errors == {"data_checker": "Invalidated due to DataChecker change."}
+
+
+def test_collect_invalidations_empty():
+    with patch("country_workspace.signals._process_program") as mock_process:
+        with collect_invalidations():
+            pass
+        mock_process.assert_not_called()
+
+
+def test_synclog_refresh_skips_save_when_attrs_unchanged(synclog_for_refresh):
+    sync, fd, ff = synclog_for_refresh
+    existing_choices = dict(fd.attrs.get("choices", []))
+
+    with patch("country_workspace.contrib.hope.client.HopeClient.get_lookup", return_value=existing_choices):
+        with patch("country_workspace.signals._process_datachecker_change"):
+            sync.refresh()
+
+    fd.refresh_from_db()
+    ff.refresh_from_db()
+    assert fd.attrs["choices"] == [list(pair) for pair in existing_choices.items()]
+
+
+def test_synclog_refresh_saves_when_attrs_changed(synclog_for_refresh):
+    sync, fd, _ff = synclog_for_refresh
+
+    with patch("country_workspace.contrib.hope.client.HopeClient.get_lookup", return_value={"new": "New"}):
+        with patch("country_workspace.signals._process_datachecker_change"):
+            sync.refresh()
+
+    fd.refresh_from_db()
+    assert fd.attrs["choices"] == [["new", "New"]]
+
+
+@pytest.fixture
+def synclog_for_manager_refresh():
+    from country_workspace.models import SyncLog
+    from hope_flex_fields.models import FieldDefinition
+    from django.contrib.contenttypes.models import ContentType
+
+    fd = FieldDefinitionFactory.create(name="test-mgr-fd", attrs={"choices": [["a", "A"]]})
+    fd.refresh_from_db()
+    ct = ContentType.objects.get_for_model(FieldDefinition)
+    return SyncLog.objects.create(content_type=ct, object_id=fd.pk, data={"remote_url": "lookups/test"})
+
+
+def test_synclog_manager_refresh_iterates_all_records(synclog_for_manager_refresh):
+    from country_workspace.models import SyncLog
+
+    with patch("country_workspace.contrib.hope.client.HopeClient.get_lookup", return_value={"b": "B"}):
+        SyncLog.objects.refresh()
+
+    fd = synclog_for_manager_refresh.content_object
+    fd.refresh_from_db()
+    assert fd.attrs["choices"] == [["b", "B"]]
 
 
 def test_signal_handler_ignores_unrecognised_instance_type():


### PR DESCRIPTION
Run sync flex fields as an async job;
Avoid invalidation if flexfield options are not changed;
Invalidate only not validated records
