### PR TITLE
Add batch cleanup action

### DIFF
--- a/src/country_workspace/workspaces/admin/batch.py
+++ b/src/country_workspace/workspaces/admin/batch.py
@@ -3,7 +3,7 @@ from typing import Any
 from admin_extra_buttons.buttons import LinkButton
 from admin_extra_buttons.decorators import button, link
 from django import forms
-from django.contrib import messages
+from django.contrib import admin, messages
 from django.contrib.admin import register
 from django.db.models import QuerySet
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
@@ -20,6 +20,33 @@ from ..permissions import can_reprocess_batch
 from ..sites import workspace
 from .filters import CWLinkedAutoCompleteFilter, ChoiceFilter, UserAutoCompleteFilter
 from .hh_ind import SelectedProgramMixin
+
+
+@admin.action(description="Batch Cleanup")
+def batch_cleanup_action(
+    model_admin: "CountryBatchAdmin",
+    request: HttpRequest,
+    queryset: "QuerySet[CountryBatch]",
+) -> None:
+    batch_ids = list(queryset.values_list("pk", flat=True))
+    if not batch_ids:
+        model_admin.message_user(request, _("No batches selected."), messages.WARNING)
+        return
+
+    job = AsyncJob.objects.create(
+        description="Batch Cleanup",
+        type=AsyncJob.JobType.TASK,
+        owner=request.user,
+        action=fqn("country_workspace.workspaces.admin.batch_cleanup.batch_cleanup"),
+        program=state.program,
+        config={"batch_ids": batch_ids},
+    )
+    job.queue()
+    model_admin.message_user(
+        request,
+        _("Batch cleanup has been scheduled for %d batch(es).") % len(batch_ids),
+        messages.SUCCESS,
+    )
 
 
 class ProgramBatchFilter(CWLinkedAutoCompleteFilter):
@@ -98,6 +125,10 @@ class CountryBatchAdmin(SelectedProgramMixin, WorkspaceModelAdmin):
     ordering = ("-import_date",)
     list_filter = (("source", ChoiceFilter), ("imported_by", UserAutoCompleteFilter))
     readonly_fields = fields = ("name", "source", "status")
+    actions = [batch_cleanup_action]
+
+    def has_delete_permission(self, request: HttpRequest, obj: CountryBatch | None = None) -> bool:
+        return False
 
     def get_common_context(self, request: HttpRequest, pk: str | None = None, **kwargs: Any) -> dict[str, Any]:
         kwargs["modeladmin"] = self

--- a/src/country_workspace/workspaces/admin/batch_cleanup.py
+++ b/src/country_workspace/workspaces/admin/batch_cleanup.py
@@ -1,0 +1,48 @@
+import logging
+from typing import Any
+
+from country_workspace.cache.handlers import suppress_cache_updates
+from country_workspace.cache.manager import cache_manager
+from country_workspace.models import AsyncJob, Batch, Household, Individual
+
+logger = logging.getLogger(__name__)
+
+
+def _clear_heavy_fields(model: type, filter_kwargs: dict) -> None:
+    model.objects.filter(**filter_kwargs).update(flex_fields={}, raw_data={}, flex_files=None)
+
+
+def batch_cleanup(job: AsyncJob) -> dict[str, Any]:
+    batch_ids = job.config.get("batch_ids")
+    if not batch_ids:
+        raise ValueError("batch_ids is required in job config")
+
+    batches = Batch.objects.filter(pk__in=batch_ids).select_related("program")
+    if not batches.exists():
+        logger.warning("No batches found for IDs: %s", batch_ids)
+        return {"batches": 0, "households": 0, "individuals": 0}
+
+    program = batches.first().program
+    deleted_counts = {"batches": 0, "households": 0, "individuals": 0}
+
+    try:
+        with suppress_cache_updates():
+            for batch_id in batch_ids:
+                job.ensure_not_cancelled(refresh=True)
+
+                _clear_heavy_fields(Individual, {"batch_id": batch_id})
+                _clear_heavy_fields(Household, {"batch_id": batch_id})
+
+                _, counts = Individual.objects.filter(batch_id=batch_id).delete()
+                deleted_counts["individuals"] += counts.get("country_workspace.Individual", 0)
+
+                _, counts = Household.objects.filter(batch_id=batch_id).delete()
+                deleted_counts["households"] += counts.get("country_workspace.Household", 0)
+
+                _, counts = Batch.objects.filter(id=batch_id).delete()
+                deleted_counts["batches"] += counts.get("country_workspace.Batch", 0)
+    finally:
+        cache_manager.incr_cache_version(program=program)
+
+    logger.info("Batch cleanup completed: %s", deleted_counts)
+    return deleted_counts

--- a/tests/workspace/admin/test_batch_cleanup_action.py
+++ b/tests/workspace/admin/test_batch_cleanup_action.py
@@ -1,0 +1,79 @@
+from unittest.mock import patch
+
+import pytest
+from django.urls import reverse
+from testutils.utils import select_office
+
+from country_workspace.models import AsyncJob
+from country_workspace.state import state
+
+
+pytestmark = [pytest.mark.admin, pytest.mark.django_db]
+
+
+@pytest.fixture
+def office():
+    from testutils.factories import OfficeFactory
+
+    co = OfficeFactory()
+    state.tenant = co
+    return co
+
+
+@pytest.fixture
+def program(office, household_checker, individual_checker):
+    from testutils.factories import CountryProgramFactory
+
+    return CountryProgramFactory(
+        household_checker=household_checker,
+        individual_checker=individual_checker,
+    )
+
+
+@pytest.fixture
+def batch(program):
+    from testutils.factories import CountryBatchFactory
+
+    return CountryBatchFactory(program=program, country_office=program.country_office)
+
+
+@pytest.fixture
+def app(django_app_factory, mocked_responses):
+    from testutils.factories import SuperUserFactory
+
+    django_app = django_app_factory(csrf_checks=False)
+    admin_user = SuperUserFactory(username="superuser")
+    django_app.set_user(admin_user)
+    django_app._user = admin_user
+    return django_app
+
+
+def test_batch_cleanup_action_creates_async_job(app, batch) -> None:
+    url = reverse("workspace:workspaces_countrybatch_changelist")
+    with select_office(app, batch.program.country_office, batch.program):
+        res = app.get(url)
+        assert res.status_code == 200
+
+        form = res.forms["changelist-form"]
+        form["action"] = "batch_cleanup_action"
+        form["_selected_action"] = [str(batch.pk)]
+        with patch.object(AsyncJob, "queue"):
+            res = form.submit()
+
+        assert res.status_code == 302
+        job = AsyncJob.objects.filter(
+            description="Batch Cleanup",
+            type=AsyncJob.JobType.TASK,
+        ).first()
+        assert job is not None
+        assert job.config["batch_ids"] == [batch.pk]
+        assert job.program == batch.program
+
+
+def test_batch_changelist_no_delete_action(app, batch) -> None:
+    url = reverse("workspace:workspaces_countrybatch_changelist")
+    with select_office(app, batch.program.country_office, batch.program):
+        res = app.get(url)
+        assert res.status_code == 200
+        assert "delete_selected" not in res.text
+        assert "Batch Cleanup" in res.text

--- a/tests/workspace/test_batch_cleanup.py
+++ b/tests/workspace/test_batch_cleanup.py
@@ -1,0 +1,166 @@
+from unittest.mock import patch
+
+import pytest
+
+from country_workspace.models import Batch, Household, Individual
+from country_workspace.models.jobs import GracefulJobCancellationError
+from country_workspace.workspaces.admin.batch_cleanup import batch_cleanup
+
+
+pytestmark = [pytest.mark.django_db]
+
+
+@pytest.fixture
+def office():
+    from testutils.factories import OfficeFactory
+
+    return OfficeFactory()
+
+
+@pytest.fixture
+def program(office, household_checker, individual_checker):
+    from testutils.factories import CountryProgramFactory
+
+    return CountryProgramFactory(
+        country_office=office,
+        household_checker=household_checker,
+        individual_checker=individual_checker,
+    )
+
+
+@pytest.fixture
+def batch(program):
+    from testutils.factories import CountryBatchFactory
+
+    return CountryBatchFactory(program=program, country_office=program.country_office)
+
+
+@pytest.fixture
+def batch_with_household(program):
+    from testutils.factories import CountryHouseholdFactory
+
+    hh = CountryHouseholdFactory(
+        batch__program=program,
+        batch__country_office=program.country_office,
+    )
+    return hh.batch, hh
+
+
+@pytest.fixture
+def batch_with_household_and_individual(batch_with_household):
+    from testutils.factories import CountryIndividualFactory
+
+    batch, hh = batch_with_household
+    ind = CountryIndividualFactory(household=hh, batch=batch)
+    return batch, hh, ind
+
+
+@pytest.fixture
+def two_batches_with_households(program):
+    from testutils.factories import CountryBatchFactory, CountryHouseholdFactory
+
+    batch1 = CountryBatchFactory(program=program, country_office=program.country_office)
+    batch2 = CountryBatchFactory(program=program, country_office=program.country_office)
+    CountryHouseholdFactory(batch=batch1)
+    CountryHouseholdFactory(batch=batch2)
+    return batch1, batch2
+
+
+@pytest.fixture
+def job_missing_config(user):
+    from testutils.factories import AsyncJobFactory
+
+    return AsyncJobFactory(owner=user, config={})
+
+
+@pytest.fixture
+def job_nonexistent_batches(user):
+    from testutils.factories import AsyncJobFactory
+
+    return AsyncJobFactory(owner=user, config={"batch_ids": [99999]})
+
+
+@pytest.fixture
+def job_for_batch(program, user, batch):
+    from testutils.factories import AsyncJobFactory
+
+    return AsyncJobFactory(
+        program=program,
+        owner=user,
+        config={"batch_ids": [batch.pk]},
+    )
+
+
+@pytest.fixture
+def job_for_batch_with_records(program, user, batch_with_household_and_individual):
+    from testutils.factories import AsyncJobFactory
+
+    batch, _, _ = batch_with_household_and_individual
+    return AsyncJobFactory(
+        program=program,
+        owner=user,
+        config={"batch_ids": [batch.pk]},
+    )
+
+
+@pytest.fixture
+def job_for_two_batches(program, user, two_batches_with_households):
+    from testutils.factories import AsyncJobFactory
+
+    batch1, batch2 = two_batches_with_households
+    return AsyncJobFactory(
+        program=program,
+        owner=user,
+        config={"batch_ids": [batch1.pk, batch2.pk]},
+    )
+
+
+def test_batch_cleanup_missing_config(job_missing_config) -> None:
+    with pytest.raises(ValueError, match="batch_ids is required"):
+        batch_cleanup(job_missing_config)
+
+
+def test_batch_cleanup_no_matching_batches(job_nonexistent_batches) -> None:
+    result = batch_cleanup(job_nonexistent_batches)
+
+    assert result == {"batches": 0, "households": 0, "individuals": 0}
+
+
+def test_batch_cleanup_empty_batch(job_for_batch, batch) -> None:
+    result = batch_cleanup(job_for_batch)
+
+    assert result["batches"] == 1
+    assert result["households"] == 0
+    assert result["individuals"] == 0
+    assert not Batch.objects.filter(pk=batch.pk).exists()
+
+
+def test_batch_cleanup_with_households_and_individuals(
+    job_for_batch_with_records, batch_with_household_and_individual
+) -> None:
+    batch, hh, ind = batch_with_household_and_individual
+
+    result = batch_cleanup(job_for_batch_with_records)
+
+    assert result["batches"] == 1
+    assert result["households"] == 1
+    assert result["individuals"] >= 1
+    assert not Batch.objects.filter(pk=batch.pk).exists()
+    assert not Household.objects.filter(pk=hh.pk).exists()
+    assert not Individual.objects.filter(pk=ind.pk).exists()
+
+
+def test_batch_cleanup_multiple_batches(job_for_two_batches, two_batches_with_households) -> None:
+    batch1, batch2 = two_batches_with_households
+
+    result = batch_cleanup(job_for_two_batches)
+
+    assert result["batches"] == 2
+    assert result["households"] == 2
+    assert not Batch.objects.filter(pk__in=[batch1.pk, batch2.pk]).exists()
+
+
+def test_batch_cleanup_respects_cancellation(job_for_batch) -> None:
+    with patch.object(job_for_batch, "ensure_not_cancelled", side_effect=GracefulJobCancellationError("cancelled")):
+        with pytest.raises(GracefulJobCancellationError):
+            batch_cleanup(job_for_batch)


### PR DESCRIPTION
[AB#315187](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/315187)


The standard Django admin delete action isn’t working properly for large datasets. It’s hitting timeouts and causing 502 errors because it tries to do too much at once.
We need to replace the standard delete functionality with a new async job called "Batch Cleanup."
