### PR TITLE
handle HoH and collectors links when batch reprocess

### DIFF
--- a/src/country_workspace/workspaces/admin/batch/__init__.py
+++ b/src/country_workspace/workspaces/admin/batch/__init__.py
@@ -1,0 +1,6 @@
+from .admin import CountryBatchAdmin, BatchReprocessForm
+
+__all__ = [
+    "BatchReprocessForm",
+    "CountryBatchAdmin",
+]

--- a/src/country_workspace/workspaces/admin/batch/admin.py
+++ b/src/country_workspace/workspaces/admin/batch/admin.py
@@ -13,13 +13,13 @@ from django.utils.translation import gettext as _
 from strategy_field.utils import fqn
 
 from country_workspace.models import AsyncJob, MappingImporter, Program, Transformer
-from ...state import state
-from ..models import CountryBatch
-from ..options import WorkspaceModelAdmin
-from ..permissions import can_reprocess_batch
-from ..sites import workspace
-from .filters import CWLinkedAutoCompleteFilter, ChoiceFilter, UserAutoCompleteFilter
-from .hh_ind import SelectedProgramMixin
+from ....state import state
+from ...models import CountryBatch
+from ...options import WorkspaceModelAdmin
+from ...permissions import can_reprocess_batch
+from ...sites import workspace
+from ..filters import CWLinkedAutoCompleteFilter, ChoiceFilter, UserAutoCompleteFilter
+from ..hh_ind import SelectedProgramMixin
 
 
 class ProgramBatchFilter(CWLinkedAutoCompleteFilter):
@@ -162,7 +162,7 @@ class CountryBatchAdmin(SelectedProgramMixin, WorkspaceModelAdmin):
                     description=f"Reprocess batch: {obj.name}",
                     type=AsyncJob.JobType.TASK,
                     owner=request.user,
-                    action=fqn("country_workspace.workspaces.admin.batch_reprocessing.reprocess_batch"),
+                    action=fqn("country_workspace.workspaces.admin.batch.reprocessing.reprocess_batch"),
                     program=obj.program,
                     batch=obj,
                     config=config,

--- a/src/country_workspace/workspaces/admin/batch/reprocessing.py
+++ b/src/country_workspace/workspaces/admin/batch/reprocessing.py
@@ -2,6 +2,10 @@ import logging
 from collections.abc import Callable
 from typing import Any
 
+from django.db.models import F, Value
+from django.db.models.expressions import CombinedExpression
+from django.db.models.fields.json import JSONField, KeyTextTransform
+
 from country_workspace.contrib.aurora.import_processing import (
     build_household_transform as build_aurora_household_processor,
     build_individual_transform as build_aurora_individual_processor,
@@ -10,9 +14,11 @@ from country_workspace.contrib.kobo.sync import (
     build_household_processor as build_kobo_household_processor,
     build_individual_processor as build_kobo_individual_processor,
 )
-from country_workspace.models import AsyncJob, Batch, Household, MappingImporter, Individual, Transformer, Program
+from country_workspace.models import AsyncJob, Batch, Household, Individual, MappingImporter, Program, Transformer
+from country_workspace.utils.collector_linkage import sync_collector_links
 from country_workspace.utils.import_processing import build_import_processor
 from country_workspace.workspaces.admin.cleaners.validate import create_validation_jobs
+
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +65,90 @@ def _build_processor(
         transformer_id=transformer_id,
         source=batch.source,
     )
+
+
+def _sync_rdi_household_refs(batch: Batch) -> None:
+    individuals = (
+        batch.individual_set.filter(removed=False)
+        .annotate(_individual_id=KeyTextTransform("individual_id", "flex_fields"))
+        .values_list("pk", "_individual_id")
+    )
+    pk_mapping = {individual_id: pk for pk, individual_id in individuals.iterator()}
+
+    households = (
+        batch.household_set.filter(removed=False)
+        .annotate(
+            _head_of_household_id=KeyTextTransform("head_of_household_id", "flex_fields"),
+            _head_of_household=KeyTextTransform("head_of_household", "flex_fields"),
+            _primary_collector_id=KeyTextTransform("primary_collector_id", "flex_fields"),
+            _primary_collector=KeyTextTransform("primary_collector", "flex_fields"),
+            _alternate_collector_id=KeyTextTransform("alternate_collector_id", "flex_fields"),
+            _alternate_collector=KeyTextTransform("alternate_collector", "flex_fields"),
+        )
+        .values_list(
+            "pk",
+            "_head_of_household_id",
+            "_head_of_household",
+            "_primary_collector_id",
+            "_primary_collector",
+            "_alternate_collector_id",
+            "_alternate_collector",
+        )
+    )
+
+    for pk, hoh_id, hoh, primary_id, primary, alt_id, alt in households.iterator():
+        patch = {
+            "head_of_household_id": pk_mapping.get(hoh_id or hoh),
+            "primary_collector_id": pk_mapping.get(primary_id or primary),
+        }
+
+        if alt_ref := alt_id or alt:
+            patch["alternate_collector_id"] = pk_mapping.get(alt_ref)
+
+        Household.objects.filter(pk=pk).update(
+            flex_fields=CombinedExpression(
+                F("flex_fields"),
+                "||",
+                Value(patch, output_field=JSONField()),
+            )
+        )
+
+
+def _sync_kobo_household_refs(batch: Batch) -> None:
+    members = (
+        batch.individual_set.filter(
+            removed=False,
+            household__removed=False,
+            household_id__isnull=False,
+        )
+        .annotate(
+            _role=KeyTextTransform("role", "flex_fields"),
+            _relationship=KeyTextTransform("relationship", "flex_fields"),
+        )
+        .values_list("household_id", "pk", "_role", "_relationship")
+        .order_by("household_id", "pk")
+    )
+
+    patches: dict[int, dict[str, int]] = {}
+
+    for household_id, pk, role, relationship in members.iterator():
+        patch = patches.setdefault(household_id, {})
+
+        if role == "PRIMARY" and "primary_collector_id" not in patch:
+            patch["primary_collector_id"] = pk
+        if role == "ALTERNATE" and "alternate_collector_id" not in patch:
+            patch["alternate_collector_id"] = pk
+        if relationship == "HEAD" and "head_of_household_id" not in patch:
+            patch["head_of_household_id"] = pk
+
+    for household_id, patch in patches.items():
+        Household.objects.filter(pk=household_id).update(
+            flex_fields=CombinedExpression(
+                F("flex_fields"),
+                "||",
+                Value(patch, output_field=JSONField()),
+            )
+        )
 
 
 def reprocess_batch(job: AsyncJob) -> dict[str, Any]:  # noqa: C901, PLR0912, PLR0915
@@ -116,8 +206,8 @@ def reprocess_batch(job: AsyncJob) -> dict[str, Any]:  # noqa: C901, PLR0912, PL
     total_households = batch.household_set.count()
     total_individuals = batch.individual_set.count()
 
-    households_to_process = batch.household_set.filter(removed=False)
-    individuals_to_process = batch.individual_set.filter(removed=False)
+    households_to_process = batch.household_set.filter(removed=False).only("pk", "name", "raw_data")
+    individuals_to_process = batch.individual_set.filter(removed=False).only("pk", "name", "raw_data")
 
     household_count = households_to_process.count()
     individual_count = individuals_to_process.count()
@@ -158,7 +248,7 @@ def reprocess_batch(job: AsyncJob) -> dict[str, Any]:  # noqa: C901, PLR0912, PL
             household_transformer.name if household_transformer else None,
             household_mapping.name if household_mapping else None,
         )
-        for household in households_to_process:
+        for household in households_to_process.iterator():
             is_applied = _apply_transformations(household, household_processor)
             mapped_households += int(is_applied)
 
@@ -171,11 +261,19 @@ def reprocess_batch(job: AsyncJob) -> dict[str, Any]:  # noqa: C901, PLR0912, PL
             individual_transformer.name if individual_transformer else None,
             individual_mapping.name if individual_mapping else None,
         )
-        for individual in individuals_to_process:
+        for individual in individuals_to_process.iterator():
             is_applied = _apply_transformations(individual, individual_processor)
             mapped_individuals += int(is_applied)
 
         logger.info("Applied transformations to %d individuals", mapped_individuals)
+
+    if is_master_detail:
+        match batch.source:
+            case Batch.BatchSource.KOBO:
+                _sync_kobo_household_refs(batch)
+            case Batch.BatchSource.RDI:
+                _sync_rdi_household_refs(batch)
+    sync_collector_links(individuals_to_process)
 
     if household_count > 0 and is_master_detail:
         create_validation_jobs(
@@ -184,7 +282,6 @@ def reprocess_batch(job: AsyncJob) -> dict[str, Any]:  # noqa: C901, PLR0912, PL
             program=batch.program,
             queryset=households_to_process.prefetch_related("members"),
         )
-
     elif individual_count > 0:
         create_validation_jobs(
             description=f"Validate records for batch {batch.pk}",

--- a/tests/workspace/admin/test_batch_reprocessing.py
+++ b/tests/workspace/admin/test_batch_reprocessing.py
@@ -9,7 +9,7 @@ from country_workspace.models import User
 from country_workspace.models import AsyncJob, Batch
 from country_workspace.workspaces.admin import CountryBatchAdmin
 from country_workspace.workspaces.admin.batch import BatchReprocessForm
-from country_workspace.workspaces.admin.batch_reprocessing import reprocess_batch
+from country_workspace.workspaces.admin.batch.reprocessing import reprocess_batch
 from country_workspace.workspaces.models import CountryBatch
 from testutils.factories.program import BeneficiaryGroupFactory
 from testutils.perms import user_grant_permissions
@@ -131,7 +131,7 @@ def test_reprocess_batch_with_households(
         config={"batch_id": batch_with_households.pk},
     )
 
-    with patch("country_workspace.workspaces.admin.batch_reprocessing.create_validation_jobs") as mock_create:
+    with patch("country_workspace.workspaces.admin.batch.reprocessing.create_validation_jobs") as mock_create:
         result = reprocess_batch(job)
 
         assert result["batch_id"] == batch_with_households.pk
@@ -155,7 +155,7 @@ def test_reprocess_batch_with_individuals(
         config={"batch_id": batch_with_individuals.pk},
     )
 
-    with patch("country_workspace.workspaces.admin.batch_reprocessing.create_validation_jobs") as mock_create:
+    with patch("country_workspace.workspaces.admin.batch.reprocessing.create_validation_jobs") as mock_create:
         result = reprocess_batch(job)
 
         assert result["batch_id"] == batch_with_individuals.pk
@@ -219,7 +219,7 @@ def test_reprocess_batch_mixed_content(
         config={"batch_id": batch_with_households.pk},
     )
 
-    with patch("country_workspace.workspaces.admin.batch_reprocessing.create_validation_jobs") as mock_create:
+    with patch("country_workspace.workspaces.admin.batch.reprocessing.create_validation_jobs") as mock_create:
         result = reprocess_batch(job)
 
         is_master_detail = batch_with_households.program.is_master_detail
@@ -288,7 +288,7 @@ def test_reprocess_button_creates_job(
         job = AsyncJob.objects.latest("id")
         assert job.batch == batch_with_households
         assert job.type == AsyncJob.JobType.TASK
-        assert "batch_reprocessing.reprocess_batch" in job.action
+        assert "batch.reprocessing.reprocess_batch" in job.action
 
 
 def test_reprocess_button_confirmation_message(app: "DjangoTestApp", batch_with_households: "CountryBatch") -> None:
@@ -462,7 +462,7 @@ def test_reprocess_batch_excludes_removed_households(
         config={"batch_id": batch_with_households.pk},
     )
 
-    with patch("country_workspace.workspaces.admin.batch_reprocessing.create_validation_jobs") as mock_create:
+    with patch("country_workspace.workspaces.admin.batch.reprocessing.create_validation_jobs") as mock_create:
         result = reprocess_batch(job)
 
         if (
@@ -513,7 +513,7 @@ def test_reprocess_batch_excludes_removed_individuals(
         config={"batch_id": batch_with_individuals.pk},
     )
 
-    with patch("country_workspace.workspaces.admin.batch_reprocessing.create_validation_jobs") as mock_create:
+    with patch("country_workspace.workspaces.admin.batch.reprocessing.create_validation_jobs") as mock_create:
         result = reprocess_batch(job)
 
         assert result["individuals"] == not_removed_count
@@ -538,7 +538,7 @@ def test_reprocess_batch_all_removed(batch_with_households: "CountryBatch", user
         config={"batch_id": batch_with_households.pk},
     )
 
-    with patch("country_workspace.workspaces.admin.batch_reprocessing.create_validation_jobs") as mock_create:
+    with patch("country_workspace.workspaces.admin.batch.reprocessing.create_validation_jobs") as mock_create:
         result = reprocess_batch(job)
 
         if (
@@ -590,7 +590,7 @@ def test_reprocess_batch_mixed_removed_status(
         config={"batch_id": batch_with_households.pk},
     )
 
-    with patch("country_workspace.workspaces.admin.batch_reprocessing.create_validation_jobs"):
+    with patch("country_workspace.workspaces.admin.batch.reprocessing.create_validation_jobs"):
         result = reprocess_batch(job)
 
         assert result.get("skipped_households", 0) == 1

--- a/tests/workspace/test_batch_reprocessing_task.py
+++ b/tests/workspace/test_batch_reprocessing_task.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from country_workspace.models import Batch, User
-from country_workspace.workspaces.admin.batch_reprocessing import reprocess_batch
+from country_workspace.workspaces.admin.batch.reprocessing import reprocess_batch
 
 
 pytestmark = [pytest.mark.django_db]
@@ -81,7 +81,7 @@ def test_reprocess_batch_with_households(program, user: User, force_migrated_rec
         config={"batch_id": batch.pk},
     )
 
-    with patch("country_workspace.workspaces.admin.batch_reprocessing.create_validation_jobs") as mock_create:
+    with patch("country_workspace.workspaces.admin.batch.reprocessing.create_validation_jobs") as mock_create:
         result = reprocess_batch(job)
 
         assert result["batch_id"] == batch.pk
@@ -111,7 +111,7 @@ def test_reprocess_batch_with_individuals_only(program, user: User, force_migrat
         config={"batch_id": batch.pk},
     )
 
-    with patch("country_workspace.workspaces.admin.batch_reprocessing.create_validation_jobs") as mock_create:
+    with patch("country_workspace.workspaces.admin.batch.reprocessing.create_validation_jobs") as mock_create:
         result = reprocess_batch(job)
 
         assert result["batch_id"] == batch.pk
@@ -123,18 +123,18 @@ def test_reprocess_batch_with_individuals_only(program, user: User, force_migrat
 
 def test_build_processor_uses_kobo_builders(program, user: User) -> None:
     from testutils.factories import CountryBatchFactory
-    from country_workspace.workspaces.admin.batch_reprocessing import _build_processor
+    from country_workspace.workspaces.admin.batch.reprocessing import _build_processor
     from country_workspace.models import Household, Individual
 
     batch = CountryBatchFactory(program=program, country_office=program.country_office, source=Batch.BatchSource.KOBO)
 
     with (
         patch(
-            "country_workspace.workspaces.admin.batch_reprocessing.build_kobo_household_processor",
+            "country_workspace.workspaces.admin.batch.reprocessing.build_kobo_household_processor",
             return_value=Mock(name="kobo_hh"),
         ) as build_hh,
         patch(
-            "country_workspace.workspaces.admin.batch_reprocessing.build_kobo_individual_processor",
+            "country_workspace.workspaces.admin.batch.reprocessing.build_kobo_individual_processor",
             return_value=Mock(name="kobo_ind"),
         ) as build_ind,
     ):
@@ -165,18 +165,18 @@ def test_build_processor_uses_kobo_builders(program, user: User) -> None:
 
 def test_build_processor_uses_aurora_builders(program, user: User) -> None:
     from testutils.factories import CountryBatchFactory
-    from country_workspace.workspaces.admin.batch_reprocessing import _build_processor
+    from country_workspace.workspaces.admin.batch.reprocessing import _build_processor
     from country_workspace.models import Household, Individual
 
     batch = CountryBatchFactory(program=program, country_office=program.country_office, source=Batch.BatchSource.AURORA)
 
     with (
         patch(
-            "country_workspace.workspaces.admin.batch_reprocessing.build_aurora_household_processor",
+            "country_workspace.workspaces.admin.batch.reprocessing.build_aurora_household_processor",
             return_value=Mock(name="aurora_hh"),
         ) as build_hh,
         patch(
-            "country_workspace.workspaces.admin.batch_reprocessing.build_aurora_individual_processor",
+            "country_workspace.workspaces.admin.batch.reprocessing.build_aurora_individual_processor",
             return_value=Mock(name="aurora_ind"),
         ) as build_ind,
     ):
@@ -207,13 +207,13 @@ def test_build_processor_uses_aurora_builders(program, user: User) -> None:
 
 def test_build_processor_uses_default_builder(program, user: User) -> None:
     from testutils.factories import CountryBatchFactory
-    from country_workspace.workspaces.admin.batch_reprocessing import _build_processor
+    from country_workspace.workspaces.admin.batch.reprocessing import _build_processor
     from country_workspace.models import Household
 
     batch = CountryBatchFactory(program=program, country_office=program.country_office, source=Batch.BatchSource.RDI)
 
     with patch(
-        "country_workspace.workspaces.admin.batch_reprocessing.build_import_processor",
+        "country_workspace.workspaces.admin.batch.reprocessing.build_import_processor",
         return_value=Mock(name="default_processor"),
     ) as build_default:
         result = _build_processor(
@@ -261,7 +261,7 @@ def test_reprocess_batch_with_mixed_content(program, user: User, force_migrated_
         config={"batch_id": batch.pk},
     )
 
-    with patch("country_workspace.workspaces.admin.batch_reprocessing.create_validation_jobs") as mock_create:
+    with patch("country_workspace.workspaces.admin.batch.reprocessing.create_validation_jobs") as mock_create:
         result = reprocess_batch(job)
 
         assert result["batch_id"] == batch.pk
@@ -295,7 +295,7 @@ def test_reprocess_batch_multiple_households(program, user: User, force_migrated
         config={"batch_id": batch.pk},
     )
 
-    with patch("country_workspace.workspaces.admin.batch_reprocessing.create_validation_jobs") as mock_create:
+    with patch("country_workspace.workspaces.admin.batch.reprocessing.create_validation_jobs") as mock_create:
         result = reprocess_batch(job)
         is_master_detail = batch.program.is_master_detail
         if is_master_detail:
@@ -324,7 +324,7 @@ def test_reprocess_batch_queryset_prefetching(program, user: User, force_migrate
         config={"batch_id": batch.pk},
     )
 
-    with patch("country_workspace.workspaces.admin.batch_reprocessing.create_validation_jobs") as mock_create:
+    with patch("country_workspace.workspaces.admin.batch.reprocessing.create_validation_jobs") as mock_create:
         reprocess_batch(job)
         is_master_detail = batch.program.is_master_detail
         calls = [c.kwargs for c in mock_create.call_args_list]
@@ -350,7 +350,7 @@ def test_reprocess_batch_result_structure(program, user: User, force_migrated_re
         config={"batch_id": batch.pk},
     )
 
-    with patch("country_workspace.workspaces.admin.batch_reprocessing.create_validation_jobs"):
+    with patch("country_workspace.workspaces.admin.batch.reprocessing.create_validation_jobs"):
         result = reprocess_batch(job)
 
         assert "batch_id" in result
@@ -391,7 +391,7 @@ def test_reprocess_batch_household_mapping_not_found(program, user: User, force_
         config={"batch_id": batch.pk, "household_mapping_id": 99999},
     )
 
-    with patch("country_workspace.workspaces.admin.batch_reprocessing.create_validation_jobs"):
+    with patch("country_workspace.workspaces.admin.batch.reprocessing.create_validation_jobs"):
         result = reprocess_batch(job)
 
         assert result["batch_id"] == batch.pk
@@ -417,7 +417,7 @@ def test_reprocess_batch_individual_mapping_not_found(program, user: User, force
         config={"batch_id": batch.pk, "individual_mapping_id": 99999},
     )
 
-    with patch("country_workspace.workspaces.admin.batch_reprocessing.create_validation_jobs"):
+    with patch("country_workspace.workspaces.admin.batch.reprocessing.create_validation_jobs"):
         result = reprocess_batch(job)
 
         assert result["batch_id"] == batch.pk
@@ -426,7 +426,7 @@ def test_reprocess_batch_individual_mapping_not_found(program, user: User, force
 
 def test_apply_transformations_no_raw_data(program, user: User) -> None:
     """Test _apply_transformations returns False when record has no raw_data."""
-    from country_workspace.workspaces.admin.batch_reprocessing import _apply_transformations
+    from country_workspace.workspaces.admin.batch.reprocessing import _apply_transformations
     from testutils.factories import CountryHouseholdFactory
 
     hh = CountryHouseholdFactory(
@@ -445,7 +445,7 @@ def test_apply_transformations_no_raw_data(program, user: User) -> None:
 
 def test_apply_transformations_successful(program, user: User) -> None:
     """Test _apply_transformations with only mapping (no transformer)."""
-    from country_workspace.workspaces.admin.batch_reprocessing import _apply_transformations
+    from country_workspace.workspaces.admin.batch.reprocessing import _apply_transformations
     from country_workspace.models import Batch, Household
     from country_workspace.utils.import_processing import build_import_processor
     from testutils.factories import CountryHouseholdFactory, MappingImporterFactory
@@ -478,7 +478,7 @@ def test_apply_transformations_successful(program, user: User) -> None:
 
 def test_apply_transformations_with_mapping_then_transformer(program, user: User) -> None:
     """Test _apply_transformations with mapping first, then transformer - correct flow."""
-    from country_workspace.workspaces.admin.batch_reprocessing import _apply_transformations
+    from country_workspace.workspaces.admin.batch.reprocessing import _apply_transformations
     from country_workspace.models import Batch, Household
     from country_workspace.utils.import_processing import build_import_processor
     from testutils.factories import CountryHouseholdFactory, MappingImporterFactory, TransformerFactory
@@ -514,7 +514,7 @@ def test_apply_transformations_with_mapping_then_transformer(program, user: User
 
 def test_apply_transformations_with_transformer_only(program, user: User) -> None:
     """Test _apply_transformations with only transformer (no mapping)."""
-    from country_workspace.workspaces.admin.batch_reprocessing import _apply_transformations
+    from country_workspace.workspaces.admin.batch.reprocessing import _apply_transformations
     from country_workspace.models import Batch, Household
     from country_workspace.utils.import_processing import build_import_processor
     from testutils.factories import CountryHouseholdFactory, TransformerFactory
@@ -548,7 +548,7 @@ def test_apply_transformations_with_transformer_only(program, user: User) -> Non
 
 def test_apply_transformations_with_neither_transformer_nor_mapping(program, user: User) -> None:
     """Test _apply_transformations with neither transformer nor mapping (both None)."""
-    from country_workspace.workspaces.admin.batch_reprocessing import _apply_transformations
+    from country_workspace.workspaces.admin.batch.reprocessing import _apply_transformations
     from country_workspace.models import Batch, Household
     from country_workspace.utils.import_processing import build_import_processor
     from testutils.factories import CountryHouseholdFactory
@@ -606,7 +606,7 @@ def test_reprocess_batch_household_mapping_applied(program, user: User, force_mi
         config={"batch_id": batch.pk, "household_mapping_id": household_mapping.pk},
     )
 
-    with patch("country_workspace.workspaces.admin.batch_reprocessing.create_validation_jobs"):
+    with patch("country_workspace.workspaces.admin.batch.reprocessing.create_validation_jobs"):
         result = reprocess_batch(job)
 
         assert result["batch_id"] == batch.pk
@@ -662,7 +662,7 @@ def test_reprocess_batch_household_mapping_then_transformer_applied(
         },
     )
 
-    with patch("country_workspace.workspaces.admin.batch_reprocessing.create_validation_jobs"):
+    with patch("country_workspace.workspaces.admin.batch.reprocessing.create_validation_jobs"):
         result = reprocess_batch(job)
 
         assert result["batch_id"] == batch.pk
@@ -717,7 +717,7 @@ def test_reprocess_batch_individual_mapping_then_transformer_applied(
         },
     )
 
-    with patch("country_workspace.workspaces.admin.batch_reprocessing.create_validation_jobs"):
+    with patch("country_workspace.workspaces.admin.batch.reprocessing.create_validation_jobs"):
         result = reprocess_batch(job)
 
         assert result["batch_id"] == batch.pk
@@ -763,7 +763,7 @@ def test_reprocess_batch_transformer_not_found(program, user: User, force_migrat
         },
     )
 
-    with patch("country_workspace.workspaces.admin.batch_reprocessing.create_validation_jobs"):
+    with patch("country_workspace.workspaces.admin.batch.reprocessing.create_validation_jobs"):
         result = reprocess_batch(job)
 
         assert result["batch_id"] == batch.pk
@@ -802,7 +802,7 @@ def test_reprocess_batch_individual_transformer_not_found(program, user: User, f
         },
     )
 
-    with patch("country_workspace.workspaces.admin.batch_reprocessing.create_validation_jobs"):
+    with patch("country_workspace.workspaces.admin.batch.reprocessing.create_validation_jobs"):
         with caplog.at_level("WARNING"):
             result = reprocess_batch(job)
 
@@ -851,7 +851,7 @@ def test_reprocess_batch_household_transformer_only(program, user: User, force_m
         },
     )
 
-    with patch("country_workspace.workspaces.admin.batch_reprocessing.create_validation_jobs"):
+    with patch("country_workspace.workspaces.admin.batch.reprocessing.create_validation_jobs"):
         result = reprocess_batch(job)
 
         assert result["batch_id"] == batch.pk
@@ -889,7 +889,7 @@ def test_reprocess_batch_individual_transformer_only(program, user: User, force_
         },
     )
 
-    with patch("country_workspace.workspaces.admin.batch_reprocessing.create_validation_jobs"):
+    with patch("country_workspace.workspaces.admin.batch.reprocessing.create_validation_jobs"):
         result = reprocess_batch(job)
 
         assert result["batch_id"] == batch.pk
@@ -924,7 +924,7 @@ def test_reprocess_batch_individual_mapping_applied(program, user: User, force_m
         config={"batch_id": batch.pk, "individual_mapping_id": individual_mapping.pk},
     )
 
-    with patch("country_workspace.workspaces.admin.batch_reprocessing.create_validation_jobs"):
+    with patch("country_workspace.workspaces.admin.batch.reprocessing.create_validation_jobs"):
         result = reprocess_batch(job)
 
         assert result["batch_id"] == batch.pk
@@ -962,7 +962,7 @@ def test_reprocess_batch_household_mapping_not_applied_when_no_households(progra
         config={"batch_id": empty_batch.pk, "household_mapping_id": household_mapping.pk},
     )
 
-    with patch("country_workspace.workspaces.admin.batch_reprocessing.create_validation_jobs"):
+    with patch("country_workspace.workspaces.admin.batch.reprocessing.create_validation_jobs"):
         result = reprocess_batch(job)
 
         assert result["batch_id"] == empty_batch.pk
@@ -1000,7 +1000,7 @@ def test_reprocess_batch_household_mapping_not_applied_when_not_master_detail(
         config={"batch_id": batch.pk, "household_mapping_id": household_mapping.pk},
     )
 
-    with patch("country_workspace.workspaces.admin.batch_reprocessing.create_validation_jobs"):
+    with patch("country_workspace.workspaces.admin.batch.reprocessing.create_validation_jobs"):
         result = reprocess_batch(job)
 
         assert result["batch_id"] == batch.pk
@@ -1028,7 +1028,7 @@ def test_reprocess_batch_individual_mapping_not_applied_when_no_individuals(prog
         config={"batch_id": empty_batch.pk, "individual_mapping_id": individual_mapping.pk},
     )
 
-    with patch("country_workspace.workspaces.admin.batch_reprocessing.create_validation_jobs"):
+    with patch("country_workspace.workspaces.admin.batch.reprocessing.create_validation_jobs"):
         result = reprocess_batch(job)
 
         assert result["batch_id"] == empty_batch.pk
@@ -1061,8 +1061,8 @@ def test_reprocess_batch_logs_skipped_records(program, user: User, force_migrate
         config={"batch_id": batch.pk},
     )
 
-    with patch("country_workspace.workspaces.admin.batch_reprocessing.create_validation_jobs"):
-        with patch("country_workspace.workspaces.admin.batch_reprocessing.logger") as mock_logger:
+    with patch("country_workspace.workspaces.admin.batch.reprocessing.create_validation_jobs"):
+        with patch("country_workspace.workspaces.admin.batch.reprocessing.logger") as mock_logger:
             result = reprocess_batch(job)
 
             assert result.get("skipped_households", 0) == 1
@@ -1074,3 +1074,71 @@ def test_reprocess_batch_logs_skipped_records(program, user: User, force_migrate
                 0,
                 batch.name,
             )
+
+
+def test_reprocess_rdi_resolves_household_refs(program, user: User, force_migrated_records) -> None:
+    from testutils.factories import (
+        AsyncJobFactory,
+        CountryBatchFactory,
+        CountryHouseholdFactory,
+        CountryIndividualFactory,
+    )
+    from testutils.factories.program import BeneficiaryGroupFactory
+
+    bg = BeneficiaryGroupFactory(master_detail=True)
+    program.beneficiary_group = bg
+    program.save()
+
+    batch = CountryBatchFactory(program=program, country_office=program.country_office, source=Batch.BatchSource.RDI)
+    household = CountryHouseholdFactory(
+        batch=batch,
+        raw_data={
+            "head_of_household": "IND-1",
+            "primary_collector": "IND-2",
+            "alternate_collector": "IND-3",
+        },
+    )
+    head = CountryIndividualFactory(batch=batch, household=household, raw_data={"individual_id": "IND-1"})
+    primary = CountryIndividualFactory(batch=batch, household=household, raw_data={"individual_id": "IND-2"})
+    alternate = CountryIndividualFactory(batch=batch, household=household, raw_data={"individual_id": "IND-3"})
+
+    job = AsyncJobFactory(program=program, batch=batch, owner=user, config={"batch_id": batch.pk})
+
+    with patch("country_workspace.workspaces.admin.batch.reprocessing.create_validation_jobs"):
+        reprocess_batch(job)
+
+    household.refresh_from_db()
+    assert household.flex_fields["head_of_household_id"] == head.pk
+    assert household.flex_fields["primary_collector_id"] == primary.pk
+    assert household.flex_fields["alternate_collector_id"] == alternate.pk
+
+
+def test_reprocess_kobo_resolves_household_refs(program, user: User, force_migrated_records) -> None:
+    from testutils.factories import (
+        AsyncJobFactory,
+        CountryBatchFactory,
+        CountryHouseholdFactory,
+        CountryIndividualFactory,
+    )
+    from testutils.factories.program import BeneficiaryGroupFactory
+
+    bg = BeneficiaryGroupFactory(master_detail=True)
+    program.beneficiary_group = bg
+    program.save()
+
+    batch = CountryBatchFactory(program=program, country_office=program.country_office, source=Batch.BatchSource.KOBO)
+    household = CountryHouseholdFactory(batch=batch, raw_data={"household_id": 1})
+    household.members.all().delete()
+    head = CountryIndividualFactory(batch=batch, household=household, raw_data={"relationship": "HEAD"})
+    primary = CountryIndividualFactory(batch=batch, household=household, raw_data={"role": "PRIMARY"})
+    alternate = CountryIndividualFactory(batch=batch, household=household, raw_data={"role": "ALTERNATE"})
+
+    job = AsyncJobFactory(program=program, batch=batch, owner=user, config={"batch_id": batch.pk})
+
+    with patch("country_workspace.workspaces.admin.batch.reprocessing.create_validation_jobs"):
+        reprocess_batch(job)
+
+    household.refresh_from_db()
+    assert household.flex_fields["head_of_household_id"] == head.pk
+    assert household.flex_fields["primary_collector_id"] == primary.pk
+    assert household.flex_fields["alternate_collector_id"] == alternate.pk


### PR DESCRIPTION
Handle HoH and collector links during Batch reprocessing.

Reprocessing now restores RDI/Kobo household references and re-runs collector link sync for active records.

[AB#315096](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/315096)
