### PR TITLE
Add functionality to run formulas on existing records

### DIFF
--- a/src/country_workspace/workspaces/admin/__init__.py
+++ b/src/country_workspace/workspaces/admin/__init__.py
@@ -5,6 +5,7 @@ from .job import CountryJobAdmin
 from .mapping_importer import CountryMappingImporterAdmin
 from .program import CountryProgramAdmin
 from .rdp import CountryRdpAdmin
+from .transformer import CountryTransformerAdmin
 
 __all__ = [
     "CountryBatchAdmin",
@@ -14,4 +15,5 @@ __all__ = [
     "CountryMappingImporterAdmin",
     "CountryProgramAdmin",
     "CountryRdpAdmin",
+    "CountryTransformerAdmin",
 ]

--- a/src/country_workspace/workspaces/admin/batch/reprocessing.py
+++ b/src/country_workspace/workspaces/admin/batch/reprocessing.py
@@ -16,7 +16,8 @@ from country_workspace.contrib.kobo.sync import (
     build_household_processor as build_kobo_household_processor,
     build_individual_processor as build_kobo_individual_processor,
 )
-from country_workspace.models import AsyncJob, Batch, Household, Individual, MappingImporter, Program
+from country_workspace.models import AsyncJob, Batch, Household, Individual, MappingImporter, Program, Transformer
+from country_workspace.utils.collector_linkage import sync_collector_links
 from country_workspace.utils.fields import to_reference_key
 from country_workspace.utils.import_flow import run_batch_postprocessing, build_import_processor
 from country_workspace.workspaces.admin.cleaners.validate import create_validation_jobs
@@ -53,6 +54,26 @@ def _preserve_flex_fields(
     ), preserved
 
 
+def _get_batch_from_job(job: AsyncJob) -> tuple[int, Batch]:
+    batch_id = job.config.get("batch_id")
+    if not batch_id:
+        raise ValueError("batch_id is required in job config")
+
+    batch = Batch.objects.select_related("program", "country_office").filter(pk=batch_id).first()
+    if not batch:
+        logger.error("Batch %s not found", batch_id)
+        raise Batch.DoesNotExist(f"Batch {batch_id} not found")
+    return batch_id, batch
+
+
+def _sync_household_refs(batch: Batch) -> None:
+    match batch.source:
+        case Batch.BatchSource.KOBO:
+            _sync_kobo_household_refs(batch)
+        case Batch.BatchSource.RDI:
+            _sync_rdi_household_refs(batch)
+
+
 def _apply_import_processor(
     record: Household | Individual,
     processor: Callable[[Any], dict[str, Any]],
@@ -71,6 +92,17 @@ def _apply_import_processor(
     record.last_checked = None
     record.errors = {}
     record.save(update_fields=["flex_fields", "last_checked", "errors"])
+    return True
+
+
+def _apply_transformer_only(record: Household | Individual, transformer: Transformer) -> bool:
+    data = record.flex_fields if isinstance(record.flex_fields, dict) else {}
+    transformed = transformer.apply(data.copy())
+    if transformed == record.flex_fields:
+        return False
+
+    record.flex_fields = transformed
+    record.save(update_fields=["flex_fields"])
     return True
 
 
@@ -180,14 +212,6 @@ def _sync_kobo_household_refs(batch: Batch) -> None:
         )
 
 
-def _sync_household_refs(batch: Batch) -> None:
-    match batch.source:
-        case Batch.BatchSource.KOBO:
-            _sync_kobo_household_refs(batch)
-        case Batch.BatchSource.RDI:
-            _sync_rdi_household_refs(batch)
-
-
 def _resolve_config_object[T](
     queryset: QuerySet[T],
     object_id: int | None,
@@ -285,11 +309,7 @@ def _active_records(
 
 
 def reprocess_batch(job: AsyncJob) -> dict[str, Any]:
-    if not (batch_id := job.config.get("batch_id")):
-        raise ValueError("batch_id is required in job config")
-    if not (batch := Batch.objects.select_related("program", "country_office").filter(pk=batch_id).first()):
-        logger.error("Batch %s not found", batch_id)
-        raise Batch.DoesNotExist(f"Batch {batch_id} not found")
+    batch_id, batch = _get_batch_from_job(job)
 
     config = _resolve_reprocess_config(batch, job.config)
     is_master_detail = batch.program.is_master_detail
@@ -377,4 +397,48 @@ def reprocess_batch(job: AsyncJob) -> dict[str, Any]:
         )
 
     logger.info("Batch reprocessing initiated: %s", response)
+    return response
+
+
+def apply_batch_transformers(job: AsyncJob) -> dict[str, Any]:
+    batch_id, batch = _get_batch_from_job(job)
+
+    household_transformer_id, household_transformer = _resolve_config_object(
+        batch.country_office.transformers.all(),
+        job.config.get("household_transformer_id"),
+        "Household transformer",
+    )
+    individual_transformer_id, individual_transformer = _resolve_config_object(
+        batch.country_office.transformers.all(),
+        job.config.get("individual_transformer_id"),
+        "Individual transformer",
+    )
+    if not household_transformer_id and not individual_transformer_id:
+        raise ValueError("At least one transformer id is required in job config")
+
+    households_to_process = batch.household_set.filter(removed=False).only("pk", "flex_fields")
+    individuals_to_process = batch.individual_set.filter(removed=False).only("pk", "flex_fields")
+    transformed_households = 0
+    transformed_individuals = 0
+
+    if batch.program.is_master_detail and household_transformer:
+        for household in households_to_process.iterator():
+            transformed_households += int(_apply_transformer_only(household, household_transformer))
+
+        _sync_household_refs(batch)
+
+    if individual_transformer:
+        for individual in individuals_to_process.iterator():
+            transformed_individuals += int(_apply_transformer_only(individual, individual_transformer))
+        sync_collector_links(individuals_to_process)
+
+    response = {
+        "batch_id": batch_id,
+        "batch_name": batch.name,
+        "transformed_individuals": transformed_individuals,
+    }
+    if batch.program.is_master_detail:
+        response["transformed_households"] = transformed_households
+
+    logger.info("Batch transformer apply finished: %s", response)
     return response

--- a/src/country_workspace/workspaces/admin/batch/reprocessing.py
+++ b/src/country_workspace/workspaces/admin/batch/reprocessing.py
@@ -16,8 +16,7 @@ from country_workspace.contrib.kobo.sync import (
     build_household_processor as build_kobo_household_processor,
     build_individual_processor as build_kobo_individual_processor,
 )
-from country_workspace.models import AsyncJob, Batch, Household, Individual, MappingImporter, Program, Transformer
-from country_workspace.utils.collector_linkage import sync_collector_links
+from country_workspace.models import AsyncJob, Batch, Household, Individual, MappingImporter, Program
 from country_workspace.utils.fields import to_reference_key
 from country_workspace.utils.import_flow import run_batch_postprocessing, build_import_processor
 from country_workspace.workspaces.admin.cleaners.validate import create_validation_jobs
@@ -92,17 +91,6 @@ def _apply_import_processor(
     record.last_checked = None
     record.errors = {}
     record.save(update_fields=["flex_fields", "last_checked", "errors"])
-    return True
-
-
-def _apply_transformer_only(record: Household | Individual, transformer: Transformer) -> bool:
-    data = record.flex_fields if isinstance(record.flex_fields, dict) else {}
-    transformed = transformer.apply(data.copy())
-    if transformed == record.flex_fields:
-        return False
-
-    record.flex_fields = transformed
-    record.save(update_fields=["flex_fields"])
     return True
 
 
@@ -403,12 +391,12 @@ def reprocess_batch(job: AsyncJob) -> dict[str, Any]:
 def apply_batch_transformers(job: AsyncJob) -> dict[str, Any]:
     batch_id, batch = _get_batch_from_job(job)
 
-    household_transformer_id, household_transformer = _resolve_config_object(
+    household_transformer_id, _ = _resolve_config_object(
         batch.country_office.transformers.all(),
         job.config.get("household_transformer_id"),
         "Household transformer",
     )
-    individual_transformer_id, individual_transformer = _resolve_config_object(
+    individual_transformer_id, _ = _resolve_config_object(
         batch.country_office.transformers.all(),
         job.config.get("individual_transformer_id"),
         "Individual transformer",
@@ -416,29 +404,20 @@ def apply_batch_transformers(job: AsyncJob) -> dict[str, Any]:
     if not household_transformer_id and not individual_transformer_id:
         raise ValueError("At least one transformer id is required in job config")
 
-    households_to_process = batch.household_set.filter(removed=False).only("pk", "flex_fields")
-    individuals_to_process = batch.individual_set.filter(removed=False).only("pk", "flex_fields")
-    transformed_households = 0
-    transformed_individuals = 0
-
-    if batch.program.is_master_detail and household_transformer:
-        for household in households_to_process.iterator():
-            transformed_households += int(_apply_transformer_only(household, household_transformer))
-
-        _sync_household_refs(batch)
-
-    if individual_transformer:
-        for individual in individuals_to_process.iterator():
-            transformed_individuals += int(_apply_transformer_only(individual, individual_transformer))
-        sync_collector_links(individuals_to_process)
+    postprocessing_result = run_batch_postprocessing(
+        batch,
+        household_transformer_id=household_transformer_id,
+        individual_transformer_id=individual_transformer_id,
+        sync_household_refs=_sync_household_refs,
+    )
 
     response = {
         "batch_id": batch_id,
         "batch_name": batch.name,
-        "transformed_individuals": transformed_individuals,
+        "transformed_individuals": postprocessing_result.get("transformed_individuals", 0),
     }
     if batch.program.is_master_detail:
-        response["transformed_households"] = transformed_households
+        response["transformed_households"] = postprocessing_result.get("transformed_households", 0)
 
     logger.info("Batch transformer apply finished: %s", response)
     return response

--- a/src/country_workspace/workspaces/admin/batch/reprocessing.py
+++ b/src/country_workspace/workspaces/admin/batch/reprocessing.py
@@ -19,6 +19,9 @@ from country_workspace.contrib.kobo.sync import (
 from country_workspace.models import AsyncJob, Batch, Household, Individual, MappingImporter, Program
 from country_workspace.utils.fields import to_reference_key
 from country_workspace.utils.import_flow import run_batch_postprocessing, build_import_processor
+from country_workspace.utils.import_flow.transformations import (
+    apply_batch_transformers as apply_transformers_to_batch,
+)
 from country_workspace.workspaces.admin.cleaners.validate import create_validation_jobs
 
 
@@ -404,20 +407,19 @@ def apply_batch_transformers(job: AsyncJob) -> dict[str, Any]:
     if not household_transformer_id and not individual_transformer_id:
         raise ValueError("At least one transformer id is required in job config")
 
-    postprocessing_result = run_batch_postprocessing(
+    transformer_result = apply_transformers_to_batch(
         batch,
         household_transformer_id=household_transformer_id,
         individual_transformer_id=individual_transformer_id,
-        sync_household_refs=_sync_household_refs,
     )
 
     response = {
         "batch_id": batch_id,
         "batch_name": batch.name,
-        "transformed_individuals": postprocessing_result.get("transformed_individuals", 0),
+        "transformed_individuals": transformer_result.get("transformed_individuals", 0),
     }
     if batch.program.is_master_detail:
-        response["transformed_households"] = postprocessing_result.get("transformed_households", 0)
+        response["transformed_households"] = transformer_result.get("transformed_households", 0)
 
     logger.info("Batch transformer apply finished: %s", response)
     return response

--- a/src/country_workspace/workspaces/admin/transformer.py
+++ b/src/country_workspace/workspaces/admin/transformer.py
@@ -1,13 +1,68 @@
-from django.contrib import admin
+from admin_extra_buttons.decorators import button
+from django import forms
+from django.contrib import admin, messages
 from django.core.cache import cache
 from django.db.models import QuerySet
 from django.forms import ModelForm
-from django.http import HttpRequest
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
+from django.shortcuts import render
+from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
+from strategy_field.utils import fqn
 
+from country_workspace.models import AsyncJob, Batch
 from country_workspace.state import state
 from country_workspace.workspaces.models import CountryTransformer
 from country_workspace.workspaces.options import WorkspaceModelAdmin
 from country_workspace.workspaces.sites import workspace
+
+
+class RunTransformerForm(forms.Form):
+    class ApplyToOptions(forms.TextChoices):
+        HOUSEHOLDS = "households", _("Households only")
+        INDIVIDUALS = "individuals", _("Individuals only")
+        BOTH = "both", _("Households and Individuals")
+
+    batch = forms.ModelChoiceField(
+        queryset=Batch.objects.none(),
+        label=_("Batch"),
+        help_text=_("Select an existing batch to update records before pushing to HOPE."),
+    )
+    apply_to = forms.ChoiceField(
+        label=_("Apply formula to"),
+        choices=ApplyToOptions.choices,
+        help_text=_("Choose which record type should be updated by this formula."),
+    )
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        office = kwargs.pop("office", None)
+        program = kwargs.pop("program", None)
+        super().__init__(*args, **kwargs)
+
+        qs = Batch.objects.order_by("-import_date")
+        if office:
+            qs = qs.filter(country_office=office)
+        if program:
+            qs = qs.filter(program=program)
+        self.fields["batch"].queryset = qs.select_related("program")
+
+        if not program:
+            self.fields["apply_to"].choices = [
+                (self.ApplyToOptions.INDIVIDUALS, self.ApplyToOptions.INDIVIDUALS.label),
+                (self.ApplyToOptions.BOTH, self.ApplyToOptions.BOTH.label),
+            ]
+            return
+
+        if program.is_master_detail:
+            self.fields["apply_to"].choices = [
+                (self.ApplyToOptions.HOUSEHOLDS, self.ApplyToOptions.HOUSEHOLDS.label),
+                (self.ApplyToOptions.INDIVIDUALS, self.ApplyToOptions.INDIVIDUALS.label),
+                (self.ApplyToOptions.BOTH, self.ApplyToOptions.BOTH.label),
+            ]
+        else:
+            self.fields["apply_to"].choices = [
+                (self.ApplyToOptions.INDIVIDUALS, self.ApplyToOptions.INDIVIDUALS.label),
+            ]
 
 
 @admin.register(CountryTransformer, site=workspace)
@@ -62,6 +117,72 @@ class CountryTransformerAdmin(WorkspaceModelAdmin):
         """Delete multiple transformers and invalidate cache."""
         super().delete_queryset(request, queryset)
         self._invalidate_transformer_cache()
+
+    @button(
+        label="Run Formula on Existing Records",
+        change_form=True,
+        html_attrs={"title": "Run this formula in Country Workspace without rule commits"},
+    )
+    def run_on_existing_records(self, request: HttpRequest, pk: str) -> HttpResponse:
+        obj = self.get_object(request, pk)
+        if not obj:
+            return HttpResponse("Transformer not found", status=404)
+
+        if request.method == "POST" and "apply" in request.POST:
+            form = RunTransformerForm(request.POST, office=state.tenant, program=state.program)
+            if form.is_valid():
+                batch = form.cleaned_data["batch"]
+                apply_to = form.cleaned_data["apply_to"]
+                if not request.user.has_perm("country_workspace.reprocess_batch", batch.program):  # type: ignore[attr-defined]
+                    self.message_user(
+                        request,
+                        _("You do not have permission to run formulas on this batch."),
+                        messages.ERROR,
+                    )
+                    return HttpResponseRedirect(self.get_change_url(request, obj))
+
+                config: dict[str, int] = {"batch_id": batch.pk}
+                if batch.program.is_master_detail and apply_to in (
+                    RunTransformerForm.ApplyToOptions.HOUSEHOLDS,
+                    RunTransformerForm.ApplyToOptions.BOTH,
+                ):
+                    config["household_transformer_id"] = obj.pk
+                if apply_to in (
+                    RunTransformerForm.ApplyToOptions.INDIVIDUALS,
+                    RunTransformerForm.ApplyToOptions.BOTH,
+                ):
+                    config["individual_transformer_id"] = obj.pk
+
+                job = AsyncJob.objects.create(
+                    description=f"Run formula '{obj.name}' on batch {batch.name}",
+                    type=AsyncJob.JobType.TASK,
+                    owner=request.user,
+                    action=fqn("country_workspace.workspaces.admin.batch.reprocessing.reprocess_batch"),
+                    program=batch.program,
+                    batch=batch,
+                    config=config,
+                )
+                job.queue()
+
+                self.message_user(
+                    request,
+                    _("Formula execution has been scheduled for the selected batch."),
+                    messages.SUCCESS,
+                )
+                return HttpResponseRedirect(reverse("workspace:workspaces_countrybatch_changelist"))
+
+            self.message_user(request, _("Please correct the errors below."), messages.ERROR)
+        else:
+            form = RunTransformerForm(office=state.tenant, program=state.program)
+
+        context = self.get_common_context(
+            request,
+            pk=pk,
+            title=_("Run Formula on Existing Records"),
+            form=form,
+            transformer=obj,
+        )
+        return render(request, "workspace/admin_extra_buttons/run_transformer_form.html", context)
 
     def _invalidate_transformer_cache(self) -> None:
         """Invalidate cache keys related to transformers."""

--- a/src/country_workspace/workspaces/admin/transformer.py
+++ b/src/country_workspace/workspaces/admin/transformer.py
@@ -70,7 +70,11 @@ class RunTransformerForm(forms.Form):
         batch = cleaned_data.get("batch")
         apply_to = cleaned_data.get("apply_to")
 
-        if batch and apply_to == self.ApplyToOptions.HOUSEHOLDS and not batch.program.is_master_detail:
+        if (
+            batch
+            and not batch.program.is_master_detail
+            and apply_to in (self.ApplyToOptions.HOUSEHOLDS, self.ApplyToOptions.BOTH)
+        ):
             self.add_error(
                 "apply_to",
                 _("Cannot apply formula to households on a program that is not master-detail."),

--- a/src/country_workspace/workspaces/admin/transformer.py
+++ b/src/country_workspace/workspaces/admin/transformer.py
@@ -122,6 +122,7 @@ class CountryTransformerAdmin(WorkspaceModelAdmin):
     @button(
         label="Run Formula on Existing Records",
         change_form=True,
+        permission="country_workspace.reprocess_batch",
         html_attrs={"title": "Run this formula in Country Workspace without rule commits"},
     )
     def run_on_existing_records(self, request: HttpRequest, pk: str) -> HttpResponse:
@@ -158,7 +159,7 @@ class CountryTransformerAdmin(WorkspaceModelAdmin):
                     description=f"Run formula '{obj.name}' on batch {batch.name}",
                     type=AsyncJob.JobType.TASK,
                     owner=request.user,
-                    action=fqn("country_workspace.workspaces.admin.batch.reprocessing.reprocess_batch"),
+                    action=fqn("country_workspace.workspaces.admin.batch.reprocessing.apply_batch_transformers"),
                     program=batch.program,
                     batch=batch,
                     config=config,

--- a/src/country_workspace/workspaces/admin/transformer.py
+++ b/src/country_workspace/workspaces/admin/transformer.py
@@ -65,6 +65,19 @@ class RunTransformerForm(forms.Form):
                 (self.ApplyToOptions.INDIVIDUALS, self.ApplyToOptions.INDIVIDUALS.label),
             ]
 
+    def clean(self) -> dict[str, object]:
+        cleaned_data = super().clean()
+        batch = cleaned_data.get("batch")
+        apply_to = cleaned_data.get("apply_to")
+
+        if batch and apply_to == self.ApplyToOptions.HOUSEHOLDS and not batch.program.is_master_detail:
+            self.add_error(
+                "apply_to",
+                _("Cannot apply formula to households on a program that is not master-detail."),
+            )
+
+        return cleaned_data
+
 
 @admin.register(CountryTransformer, site=workspace)
 class CountryTransformerAdmin(WorkspaceModelAdmin):

--- a/src/country_workspace/workspaces/admin/transformer.py
+++ b/src/country_workspace/workspaces/admin/transformer.py
@@ -2,6 +2,7 @@ from admin_extra_buttons.decorators import button
 from django import forms
 from django.contrib import admin, messages
 from django.core.cache import cache
+from django.db import models
 from django.db.models import QuerySet
 from django.forms import ModelForm
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
@@ -18,7 +19,7 @@ from country_workspace.workspaces.sites import workspace
 
 
 class RunTransformerForm(forms.Form):
-    class ApplyToOptions(forms.TextChoices):
+    class ApplyToOptions(models.TextChoices):
         HOUSEHOLDS = "households", _("Households only")
         INDIVIDUALS = "individuals", _("Individuals only")
         BOTH = "both", _("Households and Individuals")

--- a/src/country_workspace/workspaces/sites.py
+++ b/src/country_workspace/workspaces/sites.py
@@ -196,6 +196,7 @@ class TenantAdminSite(admin.AdminSite):
             "workspaces_countryhousehold": "CountryHouseholdAdmin",
             "workspaces_countryindividual": "CountryIndividualAdmin",
             "workspaces_countrybatch": "CountryBatchAdmin",
+            "workspaces_countrytransformer": "CountryTransformerAdmin",
             "workspaces_countrymappingimporter": "CountryMappingImporterAdmin",
             "workspaces_countryrdp": "CountryRdpAdmin",
             "workspaces_countryasyncjob": "CountryJobAdmin",
@@ -292,6 +293,12 @@ class TenantAdminSite(admin.AdminSite):
                         "url": reverse("workspace:workspaces_countrymappingimporter_changelist"),
                         "icon": "icon-loop",
                         "selected": current_admin == "CountryMappingImporterAdmin",
+                    },
+                    {
+                        "name": _("Transformers"),
+                        "url": reverse("workspace:workspaces_countrytransformer_changelist"),
+                        "icon": "icon-equalizer",
+                        "selected": current_admin == "CountryTransformerAdmin",
                     },
                     {
                         "name": apps.get_model("country_workspace", "Rdp")._meta.verbose_name_plural,

--- a/src/country_workspace/workspaces/templates/workspace/admin_extra_buttons/run_transformer_form.html
+++ b/src/country_workspace/workspaces/templates/workspace/admin_extra_buttons/run_transformer_form.html
@@ -1,0 +1,69 @@
+{% extends 'workspace/_base.html' %}
+{% load i18n %}
+{% block breadcrumbs %}
+{% endblock breadcrumbs %}
+{% block content %}
+    <div id="content">
+        <div id="content-main">
+            <div class="block">
+                <h1 class="text-2xl">
+                    {% translate 'Run Formula on Existing Records' %}
+                </h1>
+                <div class="block p-5">
+                    <h2>
+                        {% blocktranslate with transformer_name=transformer.name %}
+                            Formula: {{ transformer_name }}
+                        {% endblocktranslate %}
+                    </h2>
+                    <p class="mt-2">
+                        {% translate "This executes the selected formula directly in Country Workspace and updates existing records before they are pushed to HOPE." %}
+                    </p>
+                    <p class="mt-2">
+                        {% translate "No admin rule creation, rule commits, or custom code execution is required." %}
+                    </p>
+                    <form method="post" class="mt-5">
+                        {% csrf_token %}
+                        {% if form.errors %}
+                            <div class="error">
+                                <p class="errornote">
+                                    {% translate "Please correct the errors below." %}
+                                </p>
+                            </div>
+                        {% endif %}
+                        <fieldset class="module aligned">
+                            {% for field in form %}
+                                <div class="form-row {% if field.errors %}errors{% endif %}">
+                                    <div>
+                                        <label for="{{ field.id_for_label }}" class="required">
+                                            {{ field.label }}:
+                                        </label>
+                                        {{ field }}
+                                        {% if field.help_text %}
+                                            <p class="help">
+                                                {{ field.help_text }}
+                                            </p>
+                                        {% endif %}
+                                        {% if field.errors %}
+                                            <ul class="errorlist">
+                                                {% for error in field.errors %}
+                                                    <li>
+                                                        {{ error }}
+                                                    </li>
+                                                {% endfor %}
+                                            </ul>
+                                        {% endif %}
+                                    </div>
+                                </div>
+                            {% endfor %}
+                        </fieldset>
+                        <div class="mt-10">
+                            <input type="hidden" name="apply" value="yes" />
+                            <input type="submit" class="button" value="{% translate 'Run Formula' %}" />
+                            <input type="button" class="button closelink" onclick="javascript:history.back()" value="{% translate 'Go Back' %}" />
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/tests/workspace/admin/batch/test_batch_reprocessing.py
+++ b/tests/workspace/admin/batch/test_batch_reprocessing.py
@@ -485,7 +485,7 @@ def test_apply_batch_transformers_raises_for_missing_transformer(batch: CountryB
         apply_batch_transformers(job)
 
 
-def test_apply_batch_transformers_delegates_to_postprocessing(
+def test_apply_batch_transformers_delegates_to_transformations_utility(
     batch: CountryBatch,
     user: User,
     mocker,
@@ -505,18 +505,17 @@ def test_apply_batch_transformers_delegates_to_postprocessing(
         },
     )
 
-    postprocessing = mocker.patch(
-        "country_workspace.workspaces.admin.batch.reprocessing.run_batch_postprocessing",
-        return_value={"transformed_households": 3, "transformed_individuals": 7, "collector_links": 5},
+    apply_transformers = mocker.patch(
+        "country_workspace.workspaces.admin.batch.reprocessing.apply_transformers_to_batch",
+        return_value={"transformed_households": 3, "transformed_individuals": 7},
     )
 
     response = apply_batch_transformers(job)
 
-    postprocessing.assert_called_once_with(
+    apply_transformers.assert_called_once_with(
         batch,
         household_transformer_id=household_transformer.pk,
         individual_transformer_id=individual_transformer.pk,
-        sync_household_refs=_sync_household_refs,
     )
     assert response["batch_id"] == batch.pk
     assert response["batch_name"] == batch.name

--- a/tests/workspace/admin/batch/test_batch_reprocessing.py
+++ b/tests/workspace/admin/batch/test_batch_reprocessing.py
@@ -12,6 +12,7 @@ from country_workspace.workspaces.admin.batch.reprocessing import (
     _sync_household_refs,
     _sync_kobo_household_refs,
     _sync_rdi_household_refs,
+    apply_batch_transformers,
     reprocess_batch,
 )
 from country_workspace.workspaces.models import CountryBatch
@@ -447,3 +448,78 @@ def test_reprocess_batch_creates_validation_jobs_for_people_only_batch(
     assert list(validation_jobs.call_args.kwargs["queryset"]) == list(batch.individual_set.filter(removed=False))
 
     postprocessing.assert_called_once()
+
+
+# --- apply_batch_transformers ----------------------------------------------------
+
+
+def test_apply_batch_transformers_requires_batch_id(user: User) -> None:
+    from testutils.factories import AsyncJobFactory
+
+    job = AsyncJobFactory(owner=user, config={})
+
+    with pytest.raises(ValueError, match="batch_id is required"):
+        apply_batch_transformers(job)
+
+
+def test_apply_batch_transformers_requires_transformer_ids(batch: CountryBatch, user: User) -> None:
+    from testutils.factories import AsyncJobFactory
+
+    job = AsyncJobFactory(owner=user, batch=batch, program=batch.program, config={"batch_id": batch.pk})
+
+    with pytest.raises(ValueError, match="At least one transformer id is required"):
+        apply_batch_transformers(job)
+
+
+def test_apply_batch_transformers_raises_for_missing_transformer(batch: CountryBatch, user: User) -> None:
+    from testutils.factories import AsyncJobFactory
+
+    job = AsyncJobFactory(
+        owner=user,
+        batch=batch,
+        program=batch.program,
+        config={"batch_id": batch.pk, "individual_transformer_id": 999999},
+    )
+
+    with pytest.raises(ValueError, match="Individual transformer 999999 is not available for this batch"):
+        apply_batch_transformers(job)
+
+
+def test_apply_batch_transformers_delegates_to_postprocessing(
+    batch: CountryBatch,
+    user: User,
+    mocker,
+) -> None:
+    from testutils.factories import AsyncJobFactory, TransformerFactory
+
+    household_transformer = TransformerFactory(office=batch.country_office)
+    individual_transformer = TransformerFactory(office=batch.country_office)
+    job = AsyncJobFactory(
+        owner=user,
+        batch=batch,
+        program=batch.program,
+        config={
+            "batch_id": batch.pk,
+            "household_transformer_id": household_transformer.pk,
+            "individual_transformer_id": individual_transformer.pk,
+        },
+    )
+
+    postprocessing = mocker.patch(
+        "country_workspace.workspaces.admin.batch.reprocessing.run_batch_postprocessing",
+        return_value={"transformed_households": 3, "transformed_individuals": 7, "collector_links": 5},
+    )
+
+    response = apply_batch_transformers(job)
+
+    postprocessing.assert_called_once_with(
+        batch,
+        household_transformer_id=household_transformer.pk,
+        individual_transformer_id=individual_transformer.pk,
+        sync_household_refs=_sync_household_refs,
+    )
+    assert response["batch_id"] == batch.pk
+    assert response["batch_name"] == batch.name
+    assert response["transformed_individuals"] == 7
+    if batch.program.is_master_detail:
+        assert response["transformed_households"] == 3

--- a/tests/workspace/admin/test_transformer.py
+++ b/tests/workspace/admin/test_transformer.py
@@ -183,14 +183,16 @@ class TestRunOnExistingRecords:
     def test_get_renders_form(self, transformer_admin):
         request = self._build_request("GET")
         transformer = MagicMock(pk=1, name="T1")
-        state.tenant = MagicMock()
-        state.program = MagicMock()
+        state.tenant = None
+        state.program = None
+        mock_form = MagicMock()
 
         with (
             patch(
                 "country_workspace.workspaces.admin.transformer.CountryTransformerAdmin.get_object",
                 return_value=transformer,
             ),
+            patch("country_workspace.workspaces.admin.transformer.RunTransformerForm", return_value=mock_form),
             patch(
                 "country_workspace.workspaces.admin.transformer.render", return_value=HttpResponse("ok")
             ) as mock_render,
@@ -243,13 +245,16 @@ class TestRunOnExistingRecords:
                 "country_workspace.workspaces.admin.transformer.CountryTransformerAdmin.get_object",
                 return_value=transformer,
             ),
-            patch("country_workspace.workspaces.admin.transformer.RunTransformerForm", return_value=mock_form),
+            patch(
+                "country_workspace.workspaces.admin.transformer.RunTransformerForm", return_value=mock_form
+            ) as mock_form_class,
             patch(
                 "country_workspace.workspaces.admin.transformer.CountryTransformerAdmin.get_change_url",
                 return_value="/change/",
             ) as mock_get_change_url,
             patch.object(transformer_admin, "message_user") as mock_message_user,
         ):
+            mock_form_class.ApplyToOptions = RunTransformerForm.ApplyToOptions
             response = transformer_admin.run_on_existing_records(transformer_admin, request, "1")
 
         assert response.status_code == 302
@@ -278,13 +283,16 @@ class TestRunOnExistingRecords:
                 "country_workspace.workspaces.admin.transformer.CountryTransformerAdmin.get_object",
                 return_value=transformer,
             ),
-            patch("country_workspace.workspaces.admin.transformer.RunTransformerForm", return_value=mock_form),
+            patch(
+                "country_workspace.workspaces.admin.transformer.RunTransformerForm", return_value=mock_form
+            ) as mock_form_class,
             patch(
                 "country_workspace.workspaces.admin.transformer.AsyncJob.objects.create", return_value=job
             ) as mock_create,
             patch("country_workspace.workspaces.admin.transformer.reverse", return_value="/batch/"),
             patch.object(transformer_admin, "message_user") as mock_message_user,
         ):
+            mock_form_class.ApplyToOptions = RunTransformerForm.ApplyToOptions
             response = transformer_admin.run_on_existing_records(transformer_admin, request, "99")
 
         assert response.status_code == 302

--- a/tests/workspace/admin/test_transformer.py
+++ b/tests/workspace/admin/test_transformer.py
@@ -249,6 +249,7 @@ class TestRunOnExistingRecords:
             "batch": batch,
             "apply_to": RunTransformerForm.ApplyToOptions.BOTH,
         }
+        request.user.has_perm.side_effect = lambda _perm, *args: not (args and args[0] is batch.program)
 
         with (
             patch(
@@ -308,6 +309,7 @@ class TestRunOnExistingRecords:
         assert response.status_code == 302
         assert response.url == "/batch/"
         mock_create.assert_called_once()
+        assert mock_create.call_args.kwargs["action"].endswith(".apply_batch_transformers")
         assert mock_create.call_args.kwargs["config"] == {
             "batch_id": 10,
             "household_transformer_id": 99,

--- a/tests/workspace/admin/test_transformer.py
+++ b/tests/workspace/admin/test_transformer.py
@@ -3,9 +3,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 from django.contrib.auth.models import User
 from django.http import HttpRequest
+from django.http.response import HttpResponse
 
 from country_workspace.state import state
-from country_workspace.workspaces.admin.transformer import CountryTransformerAdmin
+from country_workspace.workspaces.admin.transformer import CountryTransformerAdmin, RunTransformerForm
 from country_workspace.workspaces.models import CountryTransformer
 
 
@@ -111,3 +112,170 @@ class TestCountryTransformerAdmin:
         state.tenant = None
         transformer_admin._invalidate_transformer_cache()
         mock_cache.delete.assert_not_called()
+
+
+class TestRunTransformerForm:
+    def _build_mock_queryset(self) -> MagicMock:
+        qs = MagicMock()
+        qs.filter.return_value = qs
+        qs.select_related.return_value = qs
+        qs.all.return_value = qs
+        return qs
+
+    @patch("country_workspace.workspaces.admin.transformer.Batch.objects")
+    def test_choices_without_program(self, mock_batch_objects):
+        qs = self._build_mock_queryset()
+        mock_batch_objects.order_by.return_value = qs
+
+        form = RunTransformerForm()
+
+        choices = [choice[0] for choice in form.fields["apply_to"].choices]
+        assert choices == [
+            RunTransformerForm.ApplyToOptions.INDIVIDUALS,
+            RunTransformerForm.ApplyToOptions.BOTH,
+        ]
+
+    @patch("country_workspace.workspaces.admin.transformer.Batch.objects")
+    def test_choices_master_detail_program(self, mock_batch_objects):
+        qs = self._build_mock_queryset()
+        mock_batch_objects.order_by.return_value = qs
+        program = MagicMock(is_master_detail=True)
+
+        form = RunTransformerForm(program=program)
+
+        choices = [choice[0] for choice in form.fields["apply_to"].choices]
+        assert choices == [
+            RunTransformerForm.ApplyToOptions.HOUSEHOLDS,
+            RunTransformerForm.ApplyToOptions.INDIVIDUALS,
+            RunTransformerForm.ApplyToOptions.BOTH,
+        ]
+
+    @patch("country_workspace.workspaces.admin.transformer.Batch.objects")
+    def test_choices_non_master_detail_program(self, mock_batch_objects):
+        qs = self._build_mock_queryset()
+        mock_batch_objects.order_by.return_value = qs
+        program = MagicMock(is_master_detail=False)
+
+        form = RunTransformerForm(program=program)
+
+        choices = [choice[0] for choice in form.fields["apply_to"].choices]
+        assert choices == [RunTransformerForm.ApplyToOptions.INDIVIDUALS]
+
+
+class TestRunOnExistingRecords:
+    def _build_request(self, method: str = "GET", post_data: dict | None = None, has_perm: bool = True) -> MagicMock:
+        request = MagicMock(spec=HttpRequest)
+        request.method = method
+        request.POST = post_data or {}
+        request.user = MagicMock(spec=User)
+        request.user.has_perm.return_value = has_perm
+        return request
+
+    def test_returns_404_when_transformer_not_found(self, transformer_admin):
+        request = self._build_request()
+        with patch.object(transformer_admin, "get_object", return_value=None):
+            response = transformer_admin.run_on_existing_records(request, "123")
+        assert response.status_code == 404
+
+    def test_get_renders_form(self, transformer_admin):
+        request = self._build_request("GET")
+        transformer = MagicMock(pk=1, name="T1")
+        state.tenant = MagicMock()
+        state.program = MagicMock()
+
+        with (
+            patch.object(transformer_admin, "get_object", return_value=transformer),
+            patch(
+                "country_workspace.workspaces.admin.transformer.render", return_value=HttpResponse("ok")
+            ) as mock_render,
+        ):
+            response = transformer_admin.run_on_existing_records(request, "1")
+
+        assert response.status_code == 200
+        mock_render.assert_called_once()
+
+    def test_post_invalid_form_shows_error(self, transformer_admin):
+        request = self._build_request("POST", {"apply": "yes"})
+        transformer = MagicMock(pk=1, name="T1")
+        state.tenant = MagicMock()
+        state.program = MagicMock()
+
+        mock_form = MagicMock()
+        mock_form.is_valid.return_value = False
+
+        with (
+            patch.object(transformer_admin, "get_object", return_value=transformer),
+            patch("country_workspace.workspaces.admin.transformer.RunTransformerForm", return_value=mock_form),
+            patch.object(transformer_admin, "message_user") as mock_message_user,
+            patch("country_workspace.workspaces.admin.transformer.render", return_value=HttpResponse("ok")),
+        ):
+            transformer_admin.run_on_existing_records(request, "1")
+
+        mock_message_user.assert_called()
+        assert "Please correct the errors below." in mock_message_user.call_args.args[1]
+
+    def test_post_valid_without_permission_redirects_to_change(self, transformer_admin):
+        request = self._build_request("POST", {"apply": "yes"}, has_perm=False)
+        transformer = MagicMock(pk=1, name="T1")
+        program = MagicMock(is_master_detail=True)
+        batch = MagicMock(pk=10, name="Batch 1", program=program)
+        state.tenant = MagicMock()
+        state.program = MagicMock()
+
+        mock_form = MagicMock()
+        mock_form.is_valid.return_value = True
+        mock_form.cleaned_data = {
+            "batch": batch,
+            "apply_to": RunTransformerForm.ApplyToOptions.BOTH,
+        }
+
+        with (
+            patch.object(transformer_admin, "get_object", return_value=transformer),
+            patch("country_workspace.workspaces.admin.transformer.RunTransformerForm", return_value=mock_form),
+            patch.object(transformer_admin, "get_change_url", return_value="/change/") as mock_get_change_url,
+            patch.object(transformer_admin, "message_user") as mock_message_user,
+        ):
+            response = transformer_admin.run_on_existing_records(request, "1")
+
+        assert response.status_code == 302
+        assert response.url == "/change/"
+        mock_get_change_url.assert_called_once_with(request, transformer)
+        assert "do not have permission" in mock_message_user.call_args.args[1]
+
+    def test_post_valid_schedules_job_for_both_in_master_detail(self, transformer_admin):
+        request = self._build_request("POST", {"apply": "yes"}, has_perm=True)
+        transformer = MagicMock(pk=99, name="Eligibility Rule")
+        program = MagicMock(is_master_detail=True)
+        batch = MagicMock(pk=10, name="Batch 1", program=program)
+        state.tenant = MagicMock()
+        state.program = MagicMock()
+
+        mock_form = MagicMock()
+        mock_form.is_valid.return_value = True
+        mock_form.cleaned_data = {
+            "batch": batch,
+            "apply_to": RunTransformerForm.ApplyToOptions.BOTH,
+        }
+        job = MagicMock()
+
+        with (
+            patch.object(transformer_admin, "get_object", return_value=transformer),
+            patch("country_workspace.workspaces.admin.transformer.RunTransformerForm", return_value=mock_form),
+            patch(
+                "country_workspace.workspaces.admin.transformer.AsyncJob.objects.create", return_value=job
+            ) as mock_create,
+            patch("country_workspace.workspaces.admin.transformer.reverse", return_value="/batch/"),
+            patch.object(transformer_admin, "message_user") as mock_message_user,
+        ):
+            response = transformer_admin.run_on_existing_records(request, "99")
+
+        assert response.status_code == 302
+        assert response.url == "/batch/"
+        mock_create.assert_called_once()
+        assert mock_create.call_args.kwargs["config"] == {
+            "batch_id": 10,
+            "household_transformer_id": 99,
+            "individual_transformer_id": 99,
+        }
+        job.queue.assert_called_once()
+        assert "scheduled" in mock_message_user.call_args.args[1].lower()

--- a/tests/workspace/admin/test_transformer.py
+++ b/tests/workspace/admin/test_transformer.py
@@ -173,7 +173,10 @@ class TestRunOnExistingRecords:
 
     def test_returns_404_when_transformer_not_found(self, transformer_admin):
         request = self._build_request()
-        with patch.object(transformer_admin, "get_object", return_value=None):
+        with patch(
+            "country_workspace.workspaces.admin.transformer.CountryTransformerAdmin.get_object",
+            return_value=None,
+        ):
             response = transformer_admin.run_on_existing_records(request, "123")
         assert response.status_code == 404
 
@@ -184,7 +187,10 @@ class TestRunOnExistingRecords:
         state.program = MagicMock()
 
         with (
-            patch.object(transformer_admin, "get_object", return_value=transformer),
+            patch(
+                "country_workspace.workspaces.admin.transformer.CountryTransformerAdmin.get_object",
+                return_value=transformer,
+            ),
             patch(
                 "country_workspace.workspaces.admin.transformer.render", return_value=HttpResponse("ok")
             ) as mock_render,
@@ -204,7 +210,10 @@ class TestRunOnExistingRecords:
         mock_form.is_valid.return_value = False
 
         with (
-            patch.object(transformer_admin, "get_object", return_value=transformer),
+            patch(
+                "country_workspace.workspaces.admin.transformer.CountryTransformerAdmin.get_object",
+                return_value=transformer,
+            ),
             patch("country_workspace.workspaces.admin.transformer.RunTransformerForm", return_value=mock_form),
             patch.object(transformer_admin, "message_user") as mock_message_user,
             patch("country_workspace.workspaces.admin.transformer.render", return_value=HttpResponse("ok")),
@@ -230,9 +239,15 @@ class TestRunOnExistingRecords:
         }
 
         with (
-            patch.object(transformer_admin, "get_object", return_value=transformer),
+            patch(
+                "country_workspace.workspaces.admin.transformer.CountryTransformerAdmin.get_object",
+                return_value=transformer,
+            ),
             patch("country_workspace.workspaces.admin.transformer.RunTransformerForm", return_value=mock_form),
-            patch.object(transformer_admin, "get_change_url", return_value="/change/") as mock_get_change_url,
+            patch(
+                "country_workspace.workspaces.admin.transformer.CountryTransformerAdmin.get_change_url",
+                return_value="/change/",
+            ) as mock_get_change_url,
             patch.object(transformer_admin, "message_user") as mock_message_user,
         ):
             response = transformer_admin.run_on_existing_records(request, "1")
@@ -259,7 +274,10 @@ class TestRunOnExistingRecords:
         job = MagicMock()
 
         with (
-            patch.object(transformer_admin, "get_object", return_value=transformer),
+            patch(
+                "country_workspace.workspaces.admin.transformer.CountryTransformerAdmin.get_object",
+                return_value=transformer,
+            ),
             patch("country_workspace.workspaces.admin.transformer.RunTransformerForm", return_value=mock_form),
             patch(
                 "country_workspace.workspaces.admin.transformer.AsyncJob.objects.create", return_value=job

--- a/tests/workspace/admin/test_transformer.py
+++ b/tests/workspace/admin/test_transformer.py
@@ -177,7 +177,7 @@ class TestRunOnExistingRecords:
             "country_workspace.workspaces.admin.transformer.CountryTransformerAdmin.get_object",
             return_value=None,
         ):
-            response = transformer_admin.run_on_existing_records(request, "123")
+            response = transformer_admin.run_on_existing_records(transformer_admin, request, "123")
         assert response.status_code == 404
 
     def test_get_renders_form(self, transformer_admin):
@@ -195,7 +195,7 @@ class TestRunOnExistingRecords:
                 "country_workspace.workspaces.admin.transformer.render", return_value=HttpResponse("ok")
             ) as mock_render,
         ):
-            response = transformer_admin.run_on_existing_records(request, "1")
+            response = transformer_admin.run_on_existing_records(transformer_admin, request, "1")
 
         assert response.status_code == 200
         mock_render.assert_called_once()
@@ -218,7 +218,7 @@ class TestRunOnExistingRecords:
             patch.object(transformer_admin, "message_user") as mock_message_user,
             patch("country_workspace.workspaces.admin.transformer.render", return_value=HttpResponse("ok")),
         ):
-            transformer_admin.run_on_existing_records(request, "1")
+            transformer_admin.run_on_existing_records(transformer_admin, request, "1")
 
         mock_message_user.assert_called()
         assert "Please correct the errors below." in mock_message_user.call_args.args[1]
@@ -250,7 +250,7 @@ class TestRunOnExistingRecords:
             ) as mock_get_change_url,
             patch.object(transformer_admin, "message_user") as mock_message_user,
         ):
-            response = transformer_admin.run_on_existing_records(request, "1")
+            response = transformer_admin.run_on_existing_records(transformer_admin, request, "1")
 
         assert response.status_code == 302
         assert response.url == "/change/"
@@ -285,7 +285,7 @@ class TestRunOnExistingRecords:
             patch("country_workspace.workspaces.admin.transformer.reverse", return_value="/batch/"),
             patch.object(transformer_admin, "message_user") as mock_message_user,
         ):
-            response = transformer_admin.run_on_existing_records(request, "99")
+            response = transformer_admin.run_on_existing_records(transformer_admin, request, "99")
 
         assert response.status_code == 302
         assert response.url == "/batch/"

--- a/tests/workspace/admin/test_transformer.py
+++ b/tests/workspace/admin/test_transformer.py
@@ -136,6 +136,16 @@ class TestRunTransformerForm:
         ]
 
     @patch("country_workspace.workspaces.admin.transformer.Batch.objects")
+    def test_batch_queryset_filters_by_office(self, mock_batch_objects):
+        qs = self._build_mock_queryset()
+        mock_batch_objects.order_by.return_value = qs
+        office = MagicMock()
+
+        RunTransformerForm(office=office)
+
+        qs.filter.assert_any_call(country_office=office)
+
+    @patch("country_workspace.workspaces.admin.transformer.Batch.objects")
     def test_choices_master_detail_program(self, mock_batch_objects):
         qs = self._build_mock_queryset()
         mock_batch_objects.order_by.return_value = qs

--- a/tests/workspace/admin/test_transformer.py
+++ b/tests/workspace/admin/test_transformer.py
@@ -171,6 +171,27 @@ class TestRunTransformerForm:
         choices = [choice[0] for choice in form.fields["apply_to"].choices]
         assert choices == [RunTransformerForm.ApplyToOptions.INDIVIDUALS]
 
+    @patch("country_workspace.workspaces.admin.transformer.forms.Form.clean")
+    @patch("country_workspace.workspaces.admin.transformer.Batch.objects")
+    def test_clean_rejects_households_for_non_master_detail_batch(self, mock_batch_objects, mock_form_clean):
+        qs = self._build_mock_queryset()
+        mock_batch_objects.order_by.return_value = qs
+        batch = MagicMock()
+        batch.program.is_master_detail = False
+        mock_form_clean.return_value = {
+            "batch": batch,
+            "apply_to": RunTransformerForm.ApplyToOptions.HOUSEHOLDS,
+        }
+
+        form = RunTransformerForm()
+        with patch.object(form, "add_error") as add_error:
+            form.clean()
+
+        add_error.assert_called_once()
+        field, message = add_error.call_args.args
+        assert field == "apply_to"
+        assert "not master-detail" in str(message)
+
 
 class TestRunOnExistingRecords:
     def _build_request(self, method: str = "GET", post_data: dict | None = None, has_perm: bool = True) -> MagicMock:

--- a/tests/workspace/admin/test_transformer.py
+++ b/tests/workspace/admin/test_transformer.py
@@ -171,16 +171,25 @@ class TestRunTransformerForm:
         choices = [choice[0] for choice in form.fields["apply_to"].choices]
         assert choices == [RunTransformerForm.ApplyToOptions.INDIVIDUALS]
 
+    @pytest.mark.parametrize(
+        "apply_to",
+        [
+            RunTransformerForm.ApplyToOptions.HOUSEHOLDS,
+            RunTransformerForm.ApplyToOptions.BOTH,
+        ],
+    )
     @patch("country_workspace.workspaces.admin.transformer.forms.Form.clean")
     @patch("country_workspace.workspaces.admin.transformer.Batch.objects")
-    def test_clean_rejects_households_for_non_master_detail_batch(self, mock_batch_objects, mock_form_clean):
+    def test_clean_rejects_household_targets_for_non_master_detail_batch(
+        self, mock_batch_objects, mock_form_clean, apply_to
+    ):
         qs = self._build_mock_queryset()
         mock_batch_objects.order_by.return_value = qs
         batch = MagicMock()
         batch.program.is_master_detail = False
         mock_form_clean.return_value = {
             "batch": batch,
-            "apply_to": RunTransformerForm.ApplyToOptions.HOUSEHOLDS,
+            "apply_to": apply_to,
         }
 
         form = RunTransformerForm()


### PR DESCRIPTION
- Introduced a new form, `RunTransformerForm`, to allow users to select a batch and specify the record type for formula application.
- Implemented a new admin action, `run_on_existing_records`, to handle the execution of formulas directly in the Country Workspace.
- Created a corresponding HTML template for the form, enhancing the user interface for running formulas without rule commits.
- Added permission checks to ensure users can only run formulas on batches they are authorized to process.

[AB#289969](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/289969)