### PR TITLE
feat: 315767 Filter out kobo_sys fields during import

### DIFF
--- a/src/country_workspace/contrib/kobo/sync.py
+++ b/src/country_workspace/contrib/kobo/sync.py
@@ -90,6 +90,13 @@ def extract_household_data(submission: Submission, individual_records_field: str
     return {key: value for key, value in submission.items() if key != individual_records_field}
 
 
+KOBO_SYS_FIELD_PREFIX = "kobo_sys__"
+
+
+def filter_kobo_sys_fields(data: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in data.items() if not key.split("/")[-1].startswith(KOBO_SYS_FIELD_PREFIX)}
+
+
 def normalize_json(data: dict[str, Any]) -> dict[str, Any]:
     return {key.split("/")[-1]: value for key, value in data.items()}
 
@@ -112,7 +119,7 @@ def build_household_processor(
             model=Household,
             mapping_id=mapping_id,
             fields_to_uppercase=HOUSEHOLD_FIELDS_TO_UPPERCASE,
-            pre_processors=(normalize_json,),
+            pre_processors=(filter_kobo_sys_fields, normalize_json),
             post_processors=post_processors,
             apply_defaults=apply_defaults,
             apply_mapping=apply_mapping,
@@ -136,7 +143,7 @@ def build_individual_processor(
             model=Individual,
             mapping_id=mapping_id,
             fields_to_uppercase=INDIVIDUAL_FIELDS_TO_UPPERCASE + TO_UPPERCASE_FIELDS,
-            pre_processors=(normalize_json,),
+            pre_processors=(filter_kobo_sys_fields, normalize_json),
             post_processors=post_processors,
             apply_defaults=apply_defaults,
             apply_mapping=apply_mapping,

--- a/tests/contrib/kobo/test_kobo_sync.py
+++ b/tests/contrib/kobo/test_kobo_sync.py
@@ -16,6 +16,7 @@ from country_workspace.contrib.kobo.sync import (
     create_household,
     create_individuals,
     extract_household_data,
+    filter_kobo_sys_fields,
     import_asset,
     import_data,
     is_submission_data_url,
@@ -759,6 +760,18 @@ def test_get_fullname_key_key_does_not_exist() -> None:
     assert get_fullname_key(()) is None
 
 
+def test_filter_kobo_sys_fields() -> None:
+    data = {
+        "kobo_sys__foo": "ui_value",
+        "group/kobo_sys__bar": "nested_ui_value",
+        "group/Field": "value",
+        "relationship": "head",
+    }
+    filtered = filter_kobo_sys_fields(data)
+
+    assert filtered == {"group/Field": "value", "relationship": "head"}
+
+
 def test_build_individual_processor(mocker: MockerFixture) -> None:
     from country_workspace.models import Individual
 
@@ -770,10 +783,19 @@ def test_build_individual_processor(mocker: MockerFixture) -> None:
     program_mock.apply_default_fields.side_effect = lambda model, data: {**data, "defaulted": True}
 
     processor = build_individual_processor(program_mock, mapping_id=1)
-    result = processor({"group/Field": "value", "relationship": "head"})
+    result = processor(
+        {
+            "group/Field": "value",
+            "relationship": "head",
+            "kobo_sys__ui_field": "ignored",
+            "group/kobo_sys__nested_ui": "also_ignored",
+        }
+    )
 
     assert result["field"] == "value"
     assert result["relationship"] == "HEAD"
+    assert "kobo_sys__ui_field" not in result
+    assert "nested_ui" not in result
     assert result["mapped"] is True
     assert result["defaulted"] is True
 


### PR DESCRIPTION
# Legal Boilerplate
[AB#315767](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/315767)

During the import ignore all the fields starting with kobo_sys__
These are fields used in kobo just to facilitate the form interface and ui.

Added filter_kobo_sys_fields in pre_processing for Household and Individual import
