### PR TITLE
replace deprecated ButtonWidget with StandardButton

### DIFF
--- a/src/country_workspace/workspaces/admin/rdp.py
+++ b/src/country_workspace/workspaces/admin/rdp.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import sentry_sdk
 from admin_extra_buttons.api import button, link
-from admin_extra_buttons.buttons import ButtonWidget, LinkButton
+from admin_extra_buttons.buttons import LinkButton, StandardButton
 from django.contrib import messages
 from django.contrib.admin import register
 from django.db import transaction
@@ -39,11 +39,11 @@ from .filters import ChoiceFilter
 from .hh_ind import SelectedProgramMixin
 
 
-def _is_visible(btn: ButtonWidget, action: str) -> bool:
+def _is_visible(btn: StandardButton, action: str) -> bool:
     return bool((obj := btn.original) and getattr(get_rdp_policy(obj), action)())
 
 
-def _is_allowed(btn: ButtonWidget, action: str) -> bool:
+def _is_allowed(btn: StandardButton, action: str) -> bool:
     if (obj := btn.original) is None:
         return False
     try:


### PR DESCRIPTION
Replace deprecated **ButtonWidget** with **StandardButton** [(django-admin-extra-buttons library)](https://github.com/saxix/django-admin-extra-buttons/commit/684da854e5f16f99f3f716fc1c657528d3b89eb6#diff-09dab96c2b4c7d116c67079074bfe513e521548320068dc8a4ddb70648b4f042)