### PR TITLE
Use prefixed field maps for fieldset grouping

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 
 [project]
 name = "hope-country-workspace"
-version = "0.4.6"
+version = "0.4.8"
 description = "HOPE Country Workspace (HCW)"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/country_workspace/models/mixins.py
+++ b/src/country_workspace/models/mixins.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 
 
 class FlexFieldGroupingMixin:
-    def get_grouping_info(self) -> dict[str, list[str]]:
+    def get_grouping_info(self) -> dict[str, list[tuple[str, dict[str, str]]]]:
         grouping_info = defaultdict(list)
         for member in self.checker.members.select_related("fieldset").all():
             if not member.prefix or member.group == "":
@@ -13,7 +13,9 @@ class FlexFieldGroupingMixin:
                 grouping_key = member.group
 
             if grouping_key:
-                grouping_info[grouping_key].append(member.prefix)
+                grouping_info[grouping_key].append(
+                    (member.prefix, member.fieldset.get_prefixed_field_map(member.prefix))
+                )
 
         return grouping_info
 
@@ -21,17 +23,16 @@ class FlexFieldGroupingMixin:
         def present(x: object | None) -> bool:
             return x is not None and (not isinstance(x, str) or x.strip())
 
-        def build_item(prefix: str) -> dict | None:
-            keys = [k for k in ff if k.startswith(prefix)]
-            item = {k.removeprefix(prefix): v for k in keys if present(v := ff.pop(k))}
+        def build_item(prefix: str, field_map: dict[str, str]) -> dict | None:
+            item = {name: v for name, key in field_map.items() if present(v := ff.pop(key, None))}
             return item | {"type": prefix.strip("_")} if item else None
 
         gi = self.get_grouping_info()
         ff = dict(self.flex_fields)
         grouped = {}
 
-        for group, prefixes in gi.items():
-            grouped[group] = [it for pref in prefixes if (it := build_item(pref))]
+        for group, members in gi.items():
+            grouped[group] = [it for pref, field_map in members if (it := build_item(pref, field_map))]
 
         grouped.update(ff)
         return grouped

--- a/tests/models/test_m_mixins.py
+++ b/tests/models/test_m_mixins.py
@@ -35,28 +35,42 @@ def test_get_grouping_info_empty_members(mixin_instance, mock_checker):
 
 
 def test_get_grouping_info_with_group(mixin_instance, mock_checker):
-    member1 = Mock(prefix="prefix1", group="group1", fieldset=Mock(group="fieldset_group1"))
-    member2 = Mock(prefix="prefix2", group="group1", fieldset=Mock(group="fieldset_group2"))
-    member3 = Mock(prefix="prefix3", group="group2", fieldset=Mock(group="fieldset_group3"))
+    member1 = Mock(prefix="prefix1_", group="group1", fieldset=Mock(group="fieldset_group1"))
+    member2 = Mock(prefix="prefix2_", group="group1", fieldset=Mock(group="fieldset_group2"))
+    member3 = Mock(prefix="prefix3_", group="group2", fieldset=Mock(group="fieldset_group3"))
+
+    member1.fieldset.get_prefixed_field_map.return_value = {"field1": "prefix1_field1"}
+    member2.fieldset.get_prefixed_field_map.return_value = {"field1": "prefix2_field1"}
+    member3.fieldset.get_prefixed_field_map.return_value = {"field1": "prefix3_field1"}
 
     mock_checker.members.select_related.return_value.all.return_value = [member1, member2, member3]
 
-    result = mixin_instance.get_grouping_info()
-
-    expected = {"group1": ["prefix1", "prefix2"], "group2": ["prefix3"]}
-    assert result == expected
+    assert mixin_instance.get_grouping_info() == {
+        "group1": [
+            ("prefix1_", {"field1": "prefix1_field1"}),
+            ("prefix2_", {"field1": "prefix2_field1"}),
+        ],
+        "group2": [
+            ("prefix3_", {"field1": "prefix3_field1"}),
+        ],
+    }
 
 
 def test_get_grouping_info_with_fieldset_group(mixin_instance, mock_checker):
-    member1 = Mock(prefix="prefix1", group=None, fieldset=Mock(group="fieldset_group1"))
-    member2 = Mock(prefix="prefix2", group=None, fieldset=Mock(group="fieldset_group1"))
+    member1 = Mock(prefix="prefix1_", group=None, fieldset=Mock(group="fieldset_group1"))
+    member2 = Mock(prefix="prefix2_", group=None, fieldset=Mock(group="fieldset_group1"))
+
+    member1.fieldset.get_prefixed_field_map.return_value = {"field1": "prefix1_field1"}
+    member2.fieldset.get_prefixed_field_map.return_value = {"field1": "prefix2_field1"}
 
     mock_checker.members.select_related.return_value.all.return_value = [member1, member2]
 
-    result = mixin_instance.get_grouping_info()
-
-    expected = {"fieldset_group1": ["prefix1", "prefix2"]}
-    assert result == expected
+    assert mixin_instance.get_grouping_info() == {
+        "fieldset_group1": [
+            ("prefix1_", {"field1": "prefix1_field1"}),
+            ("prefix2_", {"field1": "prefix2_field1"}),
+        ],
+    }
 
 
 def test_test_import_data_aurora_errorsapply_grouping_no_grouping_info(mixin_instance):
@@ -73,22 +87,28 @@ def test_apply_grouping_single_group(mixin_instance):
         "prefix1_field1": "value1",
         "prefix1_field2": "value2",
         "prefix2_field1": "value3",
+        "prefix2_money": True,
         "unprefixed_field": "value4",
     }
 
-    grouping_info = {"group1": ["prefix1_", "prefix2_"]}
+    grouping_info = {
+        "group1": [
+            ("prefix1_", {"field1": "prefix1_field1", "field2": "prefix1_field2"}),
+            ("prefix2_", {"field1": "prefix2_field1"}),
+        ]
+    }
 
     with patch.object(mixin_instance, "get_grouping_info", return_value=grouping_info):
         result = mixin_instance.apply_grouping()
 
-    expected = {
+    assert result == {
         "group1": [
             {"field1": "value1", "field2": "value2", "type": "prefix1"},
             {"field1": "value3", "type": "prefix2"},
         ],
+        "prefix2_money": True,
         "unprefixed_field": "value4",
     }
-    assert result == expected
 
 
 @pytest.fixture(autouse=True)
@@ -147,6 +167,7 @@ def individual(batch):
             "national_passport_country": fake.country_code(),
             "mobile_number": "P123",
             "mobile_financial_institution": "FI123",
+            "mobile_money": True,
         },
     )
 
@@ -154,11 +175,15 @@ def individual(batch):
 @pytest.mark.django_db
 def test_apply_grouping_with_documents_and_accounts(individual: "CountryIndividual"):
     result = individual.apply_grouping()
+
     assert "documents" in result
     assert "accounts" in result
     assert len(result["documents"]) == 2
     assert len(result["accounts"]) == 1
+
     assert "national_passport_document_number" not in result
     assert "mobile_number" not in result
+    assert result["mobile_money"] is True
+
     assert result["accounts"][0]["number"] == individual.flex_fields["mobile_number"]
     assert result["accounts"][0]["financial_institution"] == individual.flex_fields["mobile_financial_institution"]

--- a/uv.lock
+++ b/uv.lock
@@ -1558,7 +1558,7 @@ wheels = [
 
 [[package]]
 name = "hope-country-workspace"
-version = "0.4.6"
+version = "0.4.8"
 source = { editable = "." }
 dependencies = [
     { name = "bitcaster-sdk" },


### PR DESCRIPTION
Updated fieldset grouping to use the fieldset’s exact prefixed field map instead of matching fields by prefix only.

This prevents unrelated flat fields like `aaaa_XXX` from being accidentally grouped under a fieldset with the `aaaa_` prefix.
