### PR TITLE
feat: Add normalization for invalid multiselect values in Validable model

### DIFF
--- a/src/country_workspace/models/base.py
+++ b/src/country_workspace/models/base.py
@@ -123,9 +123,10 @@ class Validable(Cachable, models.Model):
         raise NotImplementedError
 
     @staticmethod
-    def _normalize_invalid_value_for_field(field: Any, value: Any) -> Any:
+    def _coerce_multiselect_value(field: Any, value: Any) -> Any:
         if not getattr(getattr(field, "widget", None), "allow_multiple_selected", False):
             return value
+
         if value is None:
             return []
         if isinstance(value, list):
@@ -134,9 +135,33 @@ class Validable(Cachable, models.Model):
             return list(value)
         return [value]
 
+    @classmethod
+    def _normalize_multiselect_values(cls, checker: Any, flex_fields: dict[str, Any]) -> dict[str, Any]:
+        if not flex_fields:
+            return {}
+
+        checker_fields = getattr(getattr(checker, "form", None), "fields", {})
+        if not checker_fields:
+            return dict(flex_fields)
+
+        normalized_flex_fields = dict(flex_fields)
+        for field_name, field in checker_fields.items():
+            if field_name not in normalized_flex_fields:
+                continue
+
+            normalized_flex_fields[field_name] = cls._coerce_multiselect_value(
+                field,
+                normalized_flex_fields[field_name],
+            )
+
+        return normalized_flex_fields
+
     def validate_with_checker(self, fail_if_alien: bool = False) -> bool:
         update_fields = []
-        errors = self.checker.validate([self.flex_fields], fail_if_alien=fail_if_alien)
+        flex_fields = self.flex_fields or {}
+        normalized_flex_fields = self._normalize_multiselect_values(self.checker, flex_fields)
+
+        errors = self.checker.validate([normalized_flex_fields], fail_if_alien=fail_if_alien)
         cleaned = self.checker.form.cleaned_data
         new_errors = next(iter((errors or {}).values()), {})
 
@@ -144,16 +169,13 @@ class Validable(Cachable, models.Model):
             self.errors = new_errors
             update_fields.append("errors")
 
-        flex_fields = self.flex_fields or {}
-        if cleaned != flex_fields:
+        if cleaned != normalized_flex_fields:
             self.flex_fields = cleaned
             # keep invalid values
             for field_name in new_errors:
                 if field_name in flex_fields:
                     field = self.checker.form.fields.get(field_name)
-                    self.flex_fields[field_name] = self._normalize_invalid_value_for_field(
-                        field, flex_fields[field_name]
-                    )
+                    self.flex_fields[field_name] = self._coerce_multiselect_value(field, flex_fields[field_name])
             update_fields.append("flex_fields")
 
         self.last_checked = timezone.now()

--- a/src/country_workspace/models/base.py
+++ b/src/country_workspace/models/base.py
@@ -122,6 +122,18 @@ class Validable(Cachable, models.Model):
     def checker(self) -> "DataChecker":
         raise NotImplementedError
 
+    @staticmethod
+    def _normalize_invalid_value_for_field(field: Any, value: Any) -> Any:
+        if not getattr(getattr(field, "widget", None), "allow_multiple_selected", False):
+            return value
+        if value is None:
+            return []
+        if isinstance(value, list):
+            return value
+        if isinstance(value, tuple | set):
+            return list(value)
+        return [value]
+
     def validate_with_checker(self, fail_if_alien: bool = False) -> bool:
         update_fields = []
         errors = self.checker.validate([self.flex_fields], fail_if_alien=fail_if_alien)
@@ -138,7 +150,10 @@ class Validable(Cachable, models.Model):
             # keep invalid values
             for field_name in new_errors:
                 if field_name in flex_fields:
-                    self.flex_fields[field_name] = flex_fields[field_name]
+                    field = self.checker.form.fields.get(field_name)
+                    self.flex_fields[field_name] = self._normalize_invalid_value_for_field(
+                        field, flex_fields[field_name]
+                    )
             update_fields.append("flex_fields")
 
         self.last_checked = timezone.now()

--- a/tests/models/test_m_household.py
+++ b/tests/models/test_m_household.py
@@ -86,6 +86,25 @@ def test_validate_with_checker_normalizes_multiselect_values_before_validation(h
     )
 
 
+def test_normalize_multiselect_values_skips_fields_not_present_in_payload():
+    checker = Mock()
+    checker.form = Mock(
+        fields={
+            "reasons_oos": Mock(widget=Mock(allow_multiple_selected=True)),
+            "missing_in_payload": Mock(widget=Mock(allow_multiple_selected=True)),
+        }
+    )
+    flex_fields = {"reasons_oos": "single-value"}
+
+    with mock.patch.object(
+        Validable, "_coerce_multiselect_value", wraps=Validable._coerce_multiselect_value
+    ) as coerced:
+        normalized = Validable._normalize_multiselect_values(checker, flex_fields)
+
+    assert normalized == {"reasons_oos": ["single-value"]}
+    coerced.assert_called_once_with(checker.form.fields["reasons_oos"], "single-value")
+
+
 def test_coerce_multiselect_value_passthrough_for_non_multiselect():
     field = Mock(widget=Mock(allow_multiple_selected=False))
 

--- a/tests/models/test_m_household.py
+++ b/tests/models/test_m_household.py
@@ -57,51 +57,80 @@ def test_validate_with_checker_preserves_multiselect_invalid_values_as_list(hous
     assert household.flex_fields["reasons_oos"] == ["invalid-choice"]
 
 
-def test_normalize_invalid_value_for_field_passthrough_for_non_multiselect():
+@pytest.mark.parametrize(
+    ("raw_value", "expected"),
+    [
+        ("not-eligible, missing-documents", ["not-eligible, missing-documents"]),
+        ("other security economical family", ["other security economical family"]),
+        (("reason-a", "reason-b"), ["reason-a", "reason-b"]),
+        (None, []),
+    ],
+)
+def test_validate_with_checker_normalizes_multiselect_values_before_validation(household, raw_value, expected):
+    checker = Mock()
+    checker.validate.return_value = {}
+    checker.form = Mock(
+        cleaned_data={"reasons_oos": expected},
+        fields={
+            "reasons_oos": Mock(widget=Mock(allow_multiple_selected=True)),
+        },
+    )
+    household.flex_fields = {"reasons_oos": raw_value}
+
+    with mock.patch.object(type(household), "checker", mock.PropertyMock(return_value=checker)):
+        household.validate_with_checker()
+
+    checker.validate.assert_called_once_with(
+        [{"reasons_oos": expected}],
+        fail_if_alien=False,
+    )
+
+
+def test_coerce_multiselect_value_passthrough_for_non_multiselect():
     field = Mock(widget=Mock(allow_multiple_selected=False))
 
     value = "raw-value"
-    result = Validable._normalize_invalid_value_for_field(field, value)
+    result = Validable._coerce_multiselect_value(field, value)
 
     assert result == value
 
 
-def test_normalize_invalid_value_for_field_none_for_multiselect():
+def test_coerce_multiselect_value_none_for_multiselect():
     field = Mock(widget=Mock(allow_multiple_selected=True))
 
-    result = Validable._normalize_invalid_value_for_field(field, None)
+    result = Validable._coerce_multiselect_value(field, None)
 
     assert result == []
 
 
-def test_normalize_invalid_value_for_field_list_for_multiselect():
+def test_coerce_multiselect_value_list_for_multiselect():
     field = Mock(widget=Mock(allow_multiple_selected=True))
 
     value = ["a", "b"]
-    result = Validable._normalize_invalid_value_for_field(field, value)
+    result = Validable._coerce_multiselect_value(field, value)
 
     assert result == value
 
 
-def test_normalize_invalid_value_for_field_tuple_for_multiselect():
+def test_coerce_multiselect_value_tuple_for_multiselect():
     field = Mock(widget=Mock(allow_multiple_selected=True))
 
-    result = Validable._normalize_invalid_value_for_field(field, ("a", "b"))
+    result = Validable._coerce_multiselect_value(field, ("a", "b"))
 
     assert result == ["a", "b"]
 
 
-def test_normalize_invalid_value_for_field_set_for_multiselect():
+def test_coerce_multiselect_value_set_for_multiselect():
     field = Mock(widget=Mock(allow_multiple_selected=True))
 
-    result = Validable._normalize_invalid_value_for_field(field, {"a", "b"})
+    result = Validable._coerce_multiselect_value(field, {"a", "b"})
 
     assert set(result) == {"a", "b"}
 
 
-def test_normalize_invalid_value_for_field_scalar_for_multiselect():
+def test_coerce_multiselect_value_scalar_for_multiselect():
     field = Mock(widget=Mock(allow_multiple_selected=True))
 
-    result = Validable._normalize_invalid_value_for_field(field, "single")
+    result = Validable._coerce_multiselect_value(field, "single")
 
     assert result == ["single"]

--- a/tests/models/test_m_household.py
+++ b/tests/models/test_m_household.py
@@ -4,6 +4,8 @@ from unittest.mock import Mock
 
 import pytest
 
+from country_workspace.models.base import Validable
+
 if TYPE_CHECKING:
     from country_workspace.models import Household
     from country_workspace.workspaces.models import CountryHousehold, CountryIndividual
@@ -53,3 +55,53 @@ def test_validate_with_checker_preserves_multiselect_invalid_values_as_list(hous
 
     household.refresh_from_db()
     assert household.flex_fields["reasons_oos"] == ["invalid-choice"]
+
+
+def test_normalize_invalid_value_for_field_passthrough_for_non_multiselect():
+    field = Mock(widget=Mock(allow_multiple_selected=False))
+
+    value = "raw-value"
+    result = Validable._normalize_invalid_value_for_field(field, value)
+
+    assert result == value
+
+
+def test_normalize_invalid_value_for_field_none_for_multiselect():
+    field = Mock(widget=Mock(allow_multiple_selected=True))
+
+    result = Validable._normalize_invalid_value_for_field(field, None)
+
+    assert result == []
+
+
+def test_normalize_invalid_value_for_field_list_for_multiselect():
+    field = Mock(widget=Mock(allow_multiple_selected=True))
+
+    value = ["a", "b"]
+    result = Validable._normalize_invalid_value_for_field(field, value)
+
+    assert result == value
+
+
+def test_normalize_invalid_value_for_field_tuple_for_multiselect():
+    field = Mock(widget=Mock(allow_multiple_selected=True))
+
+    result = Validable._normalize_invalid_value_for_field(field, ("a", "b"))
+
+    assert result == ["a", "b"]
+
+
+def test_normalize_invalid_value_for_field_set_for_multiselect():
+    field = Mock(widget=Mock(allow_multiple_selected=True))
+
+    result = Validable._normalize_invalid_value_for_field(field, {"a", "b"})
+
+    assert set(result) == {"a", "b"}
+
+
+def test_normalize_invalid_value_for_field_scalar_for_multiselect():
+    field = Mock(widget=Mock(allow_multiple_selected=True))
+
+    result = Validable._normalize_invalid_value_for_field(field, "single")
+
+    assert result == ["single"]

--- a/tests/models/test_m_household.py
+++ b/tests/models/test_m_household.py
@@ -35,3 +35,21 @@ def test_validate_with_checker(individual: "CountryHousehold"):
     with mock.patch.object(household.program.beneficiary_validator, "validate", Mock(return_value=["Error"])):
         assert not household.validate_with_checker()
         assert household.errors == {"dct": ["Error"]}
+
+
+def test_validate_with_checker_preserves_multiselect_invalid_values_as_list(household):
+    checker = Mock()
+    checker.validate.return_value = {household.pk: {"reasons_oos": ["Invalid value"]}}
+    checker.form = Mock(
+        cleaned_data={},
+        fields={
+            "reasons_oos": Mock(widget=Mock(allow_multiple_selected=True)),
+        },
+    )
+    household.flex_fields = {"reasons_oos": "invalid-choice"}
+
+    with mock.patch.object(type(household), "checker", mock.PropertyMock(return_value=checker)):
+        household.validate_with_checker()
+
+    household.refresh_from_db()
+    assert household.flex_fields["reasons_oos"] == ["invalid-choice"]


### PR DESCRIPTION

* Implemented a static method to normalize invalid values for fields that allow multiple selections.
* Updated the validate_with_checker method to utilize the new normalization method, ensuring invalid multiselect values are preserved as lists.
* Added a test to verify that invalid multiselect values are correctly handled and stored as lists.


[AB#319150](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/319150)