### PR TITLE
align RDI DELETE with HOPE api

### DIFF
--- a/src/country_workspace/contrib/hope/client.py
+++ b/src/country_workspace/contrib/hope/client.py
@@ -12,6 +12,7 @@ from requests.exceptions import HTTPError, RequestException
 
 from country_workspace.exceptions import RemoteError
 
+from .exceptions import HopeResponseError
 from .signals import hope_request_end, hope_request_start
 
 if TYPE_CHECKING:
@@ -107,7 +108,10 @@ class HopeClient:
         try:
             yield
         except HTTPError as e:
-            raise RemoteError(self._err(method, url, err=str(e), response=response)) from e
+            raise HopeResponseError(
+                self._err(method, url, err=str(e), response=response),
+                response=response,
+            ) from e
         except ValueError as e:
             raise RemoteError(self._err(method, url, err="invalid JSON response", response=response)) from e
 

--- a/src/country_workspace/contrib/hope/exceptions.py
+++ b/src/country_workspace/contrib/hope/exceptions.py
@@ -1,5 +1,28 @@
+from requests import Response
+
+from country_workspace.exceptions import RemoteError
+
+
 class HopePushError(Exception):
     """Exception raised for errors during the push process."""
+
+
+class HopeResponseError(RemoteError):
+    """Exception raised for a non-successful HOPE HTTP response."""
+
+    def __init__(self, message: str, *, response: Response) -> None:
+        super().__init__(message)
+        self.response = response
+
+    @property
+    def error_code(self) -> str | None:
+        try:
+            payload = self.response.json()
+        except ValueError:
+            return None
+
+        error = payload.get("error") if isinstance(payload, dict) else None
+        return error if isinstance(error, str) else None
 
 
 class HopeSyncError(Exception):

--- a/src/country_workspace/contrib/hope/push/config.py
+++ b/src/country_workspace/contrib/hope/push/config.py
@@ -1,7 +1,7 @@
 import re
 from collections.abc import Callable
-from typing import Any, TypedDict, ReadOnly, Final, NamedTuple, NotRequired
 from enum import StrEnum, auto
+from typing import Any, Final, NamedTuple, NotRequired, ReadOnly, TypedDict
 
 from country_workspace.workspaces.models import CountryHousehold, CountryIndividual
 
@@ -32,6 +32,11 @@ class PushWorkflowConfig(SelectionConfig):
     program_hope_id: ReadOnly[str]
     rdp_id: ReadOnly[int]
     country_workspace_id: NotRequired[ReadOnly[str]]
+
+
+class RdiDeleteResult(StrEnum):
+    DELETED = auto()
+    ALREADY_MERGED = auto()
 
 
 class Route(StrEnum):

--- a/src/country_workspace/contrib/hope/push/orchestration.py
+++ b/src/country_workspace/contrib/hope/push/orchestration.py
@@ -214,6 +214,9 @@ def _steps(processor: PushProcessor, config: PushWorkflowConfig) -> Iterator[Cal
 
     yield processor.preflight
     yield processor.rdi_create
+    if processor.rdi_already_merged:
+        return
+
     if config["master_detail"]:
         yield from (
             partial(processor.run_with, qs_individuals_by_household_pks(pks), processor.rdi_push_individuals),

--- a/src/country_workspace/contrib/hope/push/processor.py
+++ b/src/country_workspace/contrib/hope/push/processor.py
@@ -9,11 +9,12 @@ from django.db.models import QuerySet
 
 from country_workspace.constants import HOUSEHOLD_ROLE_REF_FIELDS
 from country_workspace.contrib.dedup_engine import make_dedup_client
-from country_workspace.models import Rdp
-from country_workspace.workspaces.models import CountryHousehold, CountryIndividual
 from country_workspace.contrib.hope.constants import IMAGES_TO_DEDUPLICATE_BULK_BATCH_SIZE, PUSH_BATCH_SIZE
 from country_workspace.exceptions import RemoteError, RemoteUnavailableError
-from .config import Serializer, ERROR_CONFIG, PushWorkflowConfig
+from country_workspace.models import Rdp
+from country_workspace.workspaces.models import CountryHousehold, CountryIndividual
+
+from .config import ERROR_CONFIG, PushWorkflowConfig, RdiDeleteResult, Serializer
 from .mappings import load_mapping_from_api, map_members, map_role_value
 from .repository import (
     existing_hope_rdi_id,
@@ -128,6 +129,7 @@ class PushProcessor(ProcessorBase):
         self.queryset: QuerySet | None = None
         self.rdp_id: int = config["rdp_id"]
         self.country_workspace_id: str | None = config.get("country_workspace_id")
+        self.rdi_already_merged: bool = False
 
     @cached_property
     def serializer(self) -> Serializer:
@@ -150,6 +152,15 @@ class PushProcessor(ProcessorBase):
         self.run_remote("RDI", lambda: self.api.complete_rdi(self.hope_rdi_id))
 
     def rdi_create(self) -> None:
+        if rdi_id := existing_hope_rdi_id(rdp_id=self.rdp_id):
+            self.hope_rdi_id = rdi_id
+            if (result := self.try_remote("RDI", lambda: self.api.delete_rdi(rdi_id))) is None:
+                return
+            if result is RdiDeleteResult.ALREADY_MERGED:
+                self.rdi_already_merged = True
+                return
+            self.hope_rdi_id = None
+
         payload = {
             "name": self.batch_name,
             "program": self.program_hope_id,
@@ -158,19 +169,12 @@ class PushProcessor(ProcessorBase):
         if self.country_workspace_id:
             payload["country_workspace_id"] = self.country_workspace_id
 
-        if rdi_id := existing_hope_rdi_id(rdp_id=self.rdp_id):
-            self.hope_rdi_id = rdi_id
-            if not self.run_remote("RDI", lambda: self.api.delete_rdi(rdi_id)):
-                return
-            self.hope_rdi_id = None
-
-        resp = self.try_remote("RDI", lambda: self.api.create_rdi(payload))
-        if resp is None:
+        if (response := self.try_remote("RDI", lambda: self.api.create_rdi(payload))) is None:
             return
-        if "id" not in resp or not resp.get("id"):
-            self.fail("RDI", "can't create: no id in response", response=resp)
+        if not (rdi_id := response.get("id")):
+            self.fail("RDI", "can't create: no id in response", response=response)
             return
-        self.hope_rdi_id = resp["id"]
+        self.hope_rdi_id = rdi_id
 
     def rdi_push_households(self) -> None:
         """Push households in batches."""

--- a/src/country_workspace/contrib/hope/push/transport.py
+++ b/src/country_workspace/contrib/hope/push/transport.py
@@ -1,9 +1,14 @@
 from collections.abc import Mapping
-from typing import Any
+from http import HTTPStatus
+from typing import Any, Final
 
 from country_workspace.contrib.hope.client import HopeClient
+from country_workspace.contrib.hope.exceptions import HopeResponseError
 
-from .config import ROUTES, Route
+from .config import ROUTES, RdiDeleteResult, Route
+
+
+RDI_ALREADY_MERGED_ERROR_CODE: Final[str] = "rdi_already_merged"
 
 
 class HopeApi:
@@ -12,10 +17,6 @@ class HopeApi:
     def __init__(self, *, co_slug: str) -> None:
         self.client = HopeClient()
         self.co_slug = co_slug
-
-    def delete_rdi(self, rdi_id: str) -> dict[str, Any]:
-        url = ROUTES[Route.DELETE_RDI].format(co_slug=self.co_slug, rdi_id=rdi_id)
-        return self.client.delete(url)
 
     def create_rdi(self, payload: Mapping[str, Any]) -> dict[str, Any]:
         return self._post(Route.CREATE_RDI, payload)
@@ -35,3 +36,16 @@ class HopeApi:
     def _post(self, route: Route, payload: Any, *, rdi_id: str | None = None) -> dict[str, Any]:
         url = ROUTES[route].format(co_slug=self.co_slug, **({"rdi_id": rdi_id} if rdi_id else {}))
         return self.client.post(url, payload)
+
+    def delete_rdi(self, rdi_id: str) -> RdiDeleteResult:
+        url = ROUTES[Route.DELETE_RDI].format(co_slug=self.co_slug, rdi_id=rdi_id)
+        try:
+            self.client.delete(url)
+        except HopeResponseError as exc:
+            match exc.response.status_code:
+                case HTTPStatus.NOT_FOUND:
+                    return RdiDeleteResult.DELETED
+                case HTTPStatus.CONFLICT if exc.error_code == RDI_ALREADY_MERGED_ERROR_CODE:
+                    return RdiDeleteResult.ALREADY_MERGED
+            raise
+        return RdiDeleteResult.DELETED

--- a/tests/contrib/hope/push/test_orchestration.py
+++ b/tests/contrib/hope/push/test_orchestration.py
@@ -35,6 +35,7 @@ def proc() -> object:
     class Proc:
         def __init__(self) -> None:
             self.calls: list[object] = []
+            self.rdi_already_merged = False
 
         def preflight(self) -> None:
             self.calls.append("pre")
@@ -580,6 +581,21 @@ def test_steps(master_detail: bool, mocker: MockerFixture, proc: object) -> None
         qs_by_pks.assert_called_once_with([1, 2])
         qs_by_hh.assert_not_called()
         qs_hh.assert_not_called()
+
+
+def test_steps_stop_for_already_merged_rdi(mocker: MockerFixture, proc: object) -> None:
+    proc.rdi_already_merged = True
+    qs_by_hh = mocker.patch(f"{MOD}.qs_individuals_by_household_pks")
+    qs_hh = mocker.patch(f"{MOD}.qs_households")
+    qs_by_pks = mocker.patch(f"{MOD}.qs_individuals_by_pks")
+
+    for step in _steps(proc, {"pks": [1], "master_detail": False}):
+        step()
+
+    assert proc.calls == ["pre", "create"]
+    qs_by_hh.assert_not_called()
+    qs_hh.assert_not_called()
+    qs_by_pks.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/tests/contrib/hope/push/test_processor.py
+++ b/tests/contrib/hope/push/test_processor.py
@@ -5,7 +5,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from country_workspace.constants import HOUSEHOLD_ROLE_REF_FIELDS
-from country_workspace.contrib.hope.push.config import Beneficiary, ERROR_CONFIG, ErrorConfig
+from country_workspace.contrib.hope.push.config import Beneficiary, ERROR_CONFIG, ErrorConfig, RdiDeleteResult
 from country_workspace.contrib.hope.push.processor import DedupProcessor, ProcessorBase, PushProcessor
 from country_workspace.exceptions import RemoteError, RemoteUnavailableError
 
@@ -153,6 +153,7 @@ def test_rdi_create_deletes_existing_rdi_before_create(
     delete = mocker.patch.object(
         processor.api,
         "delete_rdi",
+        return_value=RdiDeleteResult.DELETED,
         side_effect=RemoteError("boom") if delete_error else None,
     )
     create = mocker.patch.object(processor.api, "create_rdi", return_value={"id": "NEW-RDI"})
@@ -169,13 +170,25 @@ def test_rdi_create_deletes_existing_rdi_before_create(
         assert processor.hope_rdi_id == "NEW-RDI"
 
 
+def test_rdi_create_keeps_already_merged_rdi(mocker: MockerFixture, processor: PushProcessor) -> None:
+    mocker.patch(f"{MOD}.existing_hope_rdi_id", return_value="OLD-RDI")
+    mocker.patch.object(processor.api, "delete_rdi", return_value=RdiDeleteResult.ALREADY_MERGED)
+    create = mocker.patch.object(processor.api, "create_rdi")
+
+    processor.rdi_create()
+
+    assert processor.hope_rdi_id == "OLD-RDI"
+    assert processor.rdi_already_merged is True
+    create.assert_not_called()
+
+
 def test_rdi_create_clears_deleted_rdi_id_when_create_failed(
     mocker: MockerFixture,
     processor: PushProcessor,
     err_contains,
 ) -> None:
     mocker.patch(f"{MOD}.existing_hope_rdi_id", return_value="OLD-RDI")
-    mocker.patch.object(processor.api, "delete_rdi")
+    mocker.patch.object(processor.api, "delete_rdi", return_value=RdiDeleteResult.DELETED)
     mocker.patch.object(processor.api, "create_rdi", side_effect=RemoteError("boom"))
 
     processor.rdi_create()

--- a/tests/contrib/hope/push/test_transport.py
+++ b/tests/contrib/hope/push/test_transport.py
@@ -42,15 +42,51 @@ def test_hope_api_post_methods_delegate_to_client_post(
 
 def test_hope_api_delete_rdi_delegates_to_client_delete(mocker: MockerFixture) -> None:
     client = mocker.MagicMock()
-    client.delete.return_value = {"ok": True}
     hope_client_cls = mocker.patch.object(tr, "HopeClient", return_value=client)
 
     api = tr.HopeApi(co_slug="CO")
 
-    assert api.delete_rdi("RID") == {"ok": True}
+    assert api.delete_rdi("RID") is tr.RdiDeleteResult.DELETED
 
     hope_client_cls.assert_called_once_with()
     client.delete.assert_called_once_with(ROUTES[tr.Route.DELETE_RDI].format(co_slug="CO", rdi_id="RID"))
+
+
+@pytest.mark.parametrize(
+    ("status_code", "error_code", "expected"),
+    [
+        (404, None, tr.RdiDeleteResult.DELETED),
+        (409, tr.RDI_ALREADY_MERGED_ERROR_CODE, tr.RdiDeleteResult.ALREADY_MERGED),
+    ],
+    ids=["not_found", "already_merged"],
+)
+def test_hope_api_delete_rdi_handles_response_error(
+    mocker: MockerFixture,
+    status_code: int,
+    error_code: str | None,
+    expected: tr.RdiDeleteResult,
+) -> None:
+    response = mocker.MagicMock(status_code=status_code)
+    response.json.return_value = {"error": error_code}
+    client = mocker.MagicMock()
+    client.delete.side_effect = tr.HopeResponseError("boom", response=response)
+    mocker.patch.object(tr, "HopeClient", return_value=client)
+
+    assert tr.HopeApi(co_slug="CO").delete_rdi("RID") is expected
+
+
+def test_hope_api_delete_rdi_propagates_unhandled_response_error(mocker: MockerFixture) -> None:
+    response = mocker.MagicMock(status_code=409)
+    response.json.return_value = {"error": "rdi_merge_in_progress"}
+    error = tr.HopeResponseError("boom", response=response)
+    client = mocker.MagicMock()
+    client.delete.side_effect = error
+    mocker.patch.object(tr, "HopeClient", return_value=client)
+
+    with pytest.raises(tr.HopeResponseError) as exc_info:
+        tr.HopeApi(co_slug="CO").delete_rdi("RID")
+
+    assert exc_info.value is error
 
 
 @pytest.mark.parametrize(

--- a/tests/contrib/hope/test_hope_client.py
+++ b/tests/contrib/hope/test_hope_client.py
@@ -9,6 +9,7 @@ from constance.test import override_config
 from pytest_mock import MockerFixture
 
 from country_workspace.contrib.hope.client import HopeClient, sanitize_url
+from country_workspace.contrib.hope.exceptions import HopeResponseError
 from country_workspace.exceptions import RemoteError
 
 type Signals = tuple[Any, Any]
@@ -266,6 +267,34 @@ def test_delete_success(
     mocked_responses.add(responses.DELETE, client.get_url(DUMMY_PATH), **response_kwargs)
 
     assert client.delete(DUMMY_PATH) == expected
+    assert start.call_count == end.call_count == 1
+
+
+@pytest.mark.parametrize(
+    ("response_kwargs", "error_code"),
+    [
+        ({"json": {"error": "error_code"}, "status": 409}, "error_code"),
+        ({"json": {"error": 1}, "status": 409}, None),
+        ({"json": [], "status": 409}, None),
+        ({"body": ERROR["invalid_json"], "status": 409}, None),
+    ],
+    ids=["string_code", "non_string_code", "non_object", "invalid_json"],
+)
+def test_delete_http_error(
+    mocked_responses: responses.RequestsMock,
+    signals: Signals,
+    client: HopeClient,
+    response_kwargs: dict[str, Any],
+    error_code: str | None,
+) -> None:
+    start, end = signals
+    mocked_responses.add(responses.DELETE, client.get_url(DUMMY_PATH), **response_kwargs)
+
+    with pytest.raises(HopeResponseError) as exc_info:
+        client.delete(DUMMY_PATH)
+
+    assert exc_info.value.response.status_code == 409
+    assert exc_info.value.error_code == error_code
     assert start.call_count == end.call_count == 1
 
 


### PR DESCRIPTION
Handle HOPE RDI deletion outcomes during push retry.

- Treat `404` as a successful deletion and continue by creating a new RDI.
- Treat `409 rdi_already_merged` as an already completed push and finalize the RDP as successful using the existing HOPE RDI ID.
- All other errors continue through the existing failure flow.
