### PR TITLE
Fix failing docs deploy attempt on PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -84,6 +84,7 @@ jobs:
   # Deployment job
   deploy:
     needs: generate
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Gate the docs `deploy` job to only run on pushes to `develop`, since PR runs were failing with a GitHub Pages environment protection error when trying to deploy from the PR merge ref.